### PR TITLE
Add label to ajax promises

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -154,7 +154,7 @@ Ember.RESTAdapter = Ember.Adapter.extend({
 
 
       Ember.$.ajax(settings);
-   });
+   }, `ember-model: RESTAdapter#ajax ${method} to ${url}`);
   },
 
   _handleRejections: function(method, jqXHR, resolve, reject) {


### PR DESCRIPTION
For tooling. Mirrors ember-data: https://github.com/emberjs/data/blob/2fabe2e86dfa6561d9d0038d4726e5fcc4658320/addon/adapters/rest.js#L1075

https://guides.emberjs.com/v2.11.0/ember-inspector/promises/#toc_labeling-promises

ember-cli-sentry will automatically use these labels for context when reporting unhandled promise rejections: https://github.com/damiencaselli/ember-cli-sentry/commit/4768fed9f9f630d726fae9f007956fbe0623993a#diff-8be509db1b5529feb03560bf2dd81192R106