### PR TITLE
comment out container

### DIFF
--- a/packages/ember-model/lib/store.js
+++ b/packages/ember-model/lib/store.js
@@ -1,7 +1,7 @@
 function NIL() {}
 
 Ember.Model.Store = Ember.Object.extend({
-  container: null,
+  //container: null, //NOTE: GJ: see https://github.com/emberjs/ember.js/issues/15322#issuecomment-334132107
 
   modelFor: function(type) {
     return this.container.lookupFactory('model:'+type);


### PR DESCRIPTION
See https://github.com/emberjs/ember.js/issues/15322#issuecomment-334132107

This will buy us some time with ember-model and should unblock our upgrade to `2.13.4`. We're going to have either address this in ember-model or migrate fully to Ember Data before Ember 3.0.