### PR TITLE
Ember 3.10.0

### DIFF
--- a/ember-model.js
+++ b/ember-model.js
@@ -4,205 +4,224 @@
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-// 0.0.14-78-g1a35b19
-// 1a35b19 (2019-04-10 09:36:18 +0100)
+// 3.10.0-intercom.1
+// 362dcfb (2019-05-14 14:20:15 +0100)
 
 (function() {
+  var VERSION = "3.10.0-intercom.1";
 
-  var VERSION = '3.8.0-intercom.1';
-  
   if (Ember.libraries) {
-    Ember.libraries.register('Ember Model', VERSION);
+    Ember.libraries.register("Ember Model", VERSION);
   }
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   function mustImplement(message) {
     var fn = function() {
       var className = this.constructor.toString();
-  
-      throw new Error(message.replace('{{className}}', className));
+
+      throw new Error(message.replace("{{className}}", className));
     };
     fn.isUnimplemented = true;
     return fn;
   }
-  
+
   Ember.Adapter = Ember.Object.extend({
-    find: mustImplement('{{className}} must implement find'),
-    findQuery: mustImplement('{{className}} must implement findQuery'),
-    findMany: mustImplement('{{className}} must implement findMany'),
-    findAll: mustImplement('{{className}} must implement findAll'),
-    createRecord: mustImplement('{{className}} must implement createRecord'),
-    saveRecord: mustImplement('{{className}} must implement saveRecord'),
-    deleteRecord: mustImplement('{{className}} must implement deleteRecord'),
-  
+    find: mustImplement("{{className}} must implement find"),
+    findQuery: mustImplement("{{className}} must implement findQuery"),
+    findMany: mustImplement("{{className}} must implement findMany"),
+    findAll: mustImplement("{{className}} must implement findAll"),
+    createRecord: mustImplement("{{className}} must implement createRecord"),
+    saveRecord: mustImplement("{{className}} must implement saveRecord"),
+    deleteRecord: mustImplement("{{className}} must implement deleteRecord"),
+
     load: function(record, id, data) {
       record.load(id, data);
     }
   });
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   var get = Ember.get,
-      set = Ember.set;
-  
+    set = Ember.set;
+
   Ember.FixtureAdapter = Ember.Adapter.extend({
     _counter: 0,
     _findData: function(klass, id) {
       var fixtures = klass.FIXTURES,
-          idAsString = id.toString(),
-          primaryKey = get(klass, 'primaryKey'),
-          data = Ember.A(fixtures).find(function(el) { return (el[primaryKey]).toString() === idAsString; });
-  
+        idAsString = id.toString(),
+        primaryKey = get(klass, "primaryKey"),
+        data = Ember.A(fixtures).find(function(el) {
+          return el[primaryKey].toString() === idAsString;
+        });
+
       return data;
     },
-  
+
     _setPrimaryKey: function(record) {
       var klass = record.constructor,
-          fixtures = klass.FIXTURES,
-          primaryKey = get(klass, 'primaryKey');
-  
-  
-      if(record.get(primaryKey)) {
+        fixtures = klass.FIXTURES,
+        primaryKey = get(klass, "primaryKey");
+
+      if (record.get(primaryKey)) {
         return;
       }
-  
+
       set(record, primaryKey, this._generatePrimaryKey());
     },
-  
+
     _generatePrimaryKey: function() {
       var counter = this.get("_counter");
-  
+
       this.set("_counter", counter + 1);
-  
+
       return "fixture-" + counter;
     },
-  
+
     find: function(record, id) {
       var data = this._findData(record.constructor, id);
-  
+
       return new Ember.RSVP.Promise(function(resolve, reject) {
-        Ember.run.later(this, function() {
-          Ember.run(record, record.load, id, data);
-          resolve(record);
-        }, 0);
+        Ember.run.later(
+          this,
+          function() {
+            Ember.run(record, record.load, id, data);
+            resolve(record);
+          },
+          0
+        );
       });
     },
-  
+
     findMany: function(klass, records, ids) {
       var fixtures = klass.FIXTURES,
-          requestedData = [];
-  
+        requestedData = [];
+
       for (var i = 0, l = ids.length; i < l; i++) {
         requestedData.push(this._findData(klass, ids[i]));
       }
-  
+
       return new Ember.RSVP.Promise(function(resolve, reject) {
-        Ember.run.later(this, function() {
-          Ember.run(records, records.load, klass, requestedData);
-          resolve(records);
-        }, 0);
+        Ember.run.later(
+          this,
+          function() {
+            Ember.run(records, records.load, klass, requestedData);
+            resolve(records);
+          },
+          0
+        );
       });
     },
-  
+
     findAll: function(klass, records) {
       var fixtures = klass.FIXTURES;
-  
+
       return new Ember.RSVP.Promise(function(resolve, reject) {
-        Ember.run.later(this, function() {
-          Ember.run(records, records.load, klass, fixtures);
-          resolve(records);
-        }, 0);
+        Ember.run.later(
+          this,
+          function() {
+            Ember.run(records, records.load, klass, fixtures);
+            resolve(records);
+          },
+          0
+        );
       });
     },
-  
+
     createRecord: function(record) {
       var klass = record.constructor,
-          fixtures = klass.FIXTURES,
-          self = this;
-  
+        fixtures = klass.FIXTURES,
+        self = this;
+
       return new Ember.RSVP.Promise(function(resolve, reject) {
-        Ember.run.later(this, function() {
-          var rootKey = record.constructor.rootKey,
+        Ember.run.later(
+          this,
+          function() {
+            var rootKey = record.constructor.rootKey,
               json;
-  
-          self._setPrimaryKey(record);
-          json = rootKey ? record.toJSON()[rootKey] : record.toJSON();
-          fixtures.push(klass.findFromCacheOrLoad(json));
-          record.didCreateRecord();
-          resolve(record);
-        }, 0);
+
+            self._setPrimaryKey(record);
+            json = rootKey ? record.toJSON()[rootKey] : record.toJSON();
+            fixtures.push(klass.findFromCacheOrLoad(json));
+            record.didCreateRecord();
+            resolve(record);
+          },
+          0
+        );
       });
     },
-  
+
     saveRecord: function(record) {
       return new Ember.RSVP.Promise(function(resolve, reject) {
-        Ember.run.later(this, function() {
-          record.didSaveRecord();
-          resolve(record);
-        }, 0);
+        Ember.run.later(
+          this,
+          function() {
+            record.didSaveRecord();
+            resolve(record);
+          },
+          0
+        );
       });
     },
-  
+
     deleteRecord: function(record) {
       return new Ember.RSVP.Promise(function(resolve, reject) {
-        Ember.run.later(this, function() {
-          record.didDeleteRecord();
-          resolve(record);
-        }, 0);
+        Ember.run.later(
+          this,
+          function() {
+            record.didDeleteRecord();
+            resolve(record);
+          },
+          0
+        );
       });
     }
   });
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   var get = Ember.get,
-      set = Ember.set;
-  
+    set = Ember.set;
+
   Ember.RecordArray = Ember.ArrayProxy.extend(Ember.Evented, {
     isLoaded: false,
-    isLoading: Ember.computed.not('isLoaded'),
-  
+    isLoading: Ember.computed.not("isLoaded"),
+
     load: function(klass, data) {
-      set(this, 'content', this.materializeData(klass, data));
+      set(this, "content", this.materializeData(klass, data));
       this.notifyLoaded();
     },
-  
+
     loadForFindMany: function(klass) {
       var self = this;
-      var content = get(this, '_ids').map(function(id) { return klass.cachedRecordForId(id, Ember.getOwner(self)); });
-      set(this, 'content', Ember.A(content));
+      var content = get(this, "_ids").map(function(id) {
+        return klass.cachedRecordForId(id, Ember.getOwner(self));
+      });
+      set(this, "content", Ember.A(content));
       this.notifyLoaded();
     },
-  
+
     notifyLoaded: function() {
-      set(this, 'isLoaded', true);
-      this.trigger('didLoad');
+      set(this, "isLoaded", true);
+      this.trigger("didLoad");
     },
-  
+
     materializeData: function(klass, data) {
       var self = this;
       var owner = Ember.getOwner(this);
-      return Ember.A(data.map(function(el) {
-        return klass.findFromCacheOrLoad(el, owner);
-      }));
+      return Ember.A(
+        data.map(function(el) {
+          return klass.findFromCacheOrLoad(el, owner);
+        })
+      );
     },
-  
+
     reload: function() {
-      var modelClass = this.get('modelClass'),
-          self = this,
-          promises;
-  
-      set(this, 'isLoaded', false);
+      var modelClass = this.get("modelClass"),
+        self = this,
+        promises;
+
+      set(this, "isLoaded", false);
       if (modelClass._findAllRecordArray === this) {
         return modelClass.adapter.findAll(modelClass, this);
       } else if (this._query) {
@@ -217,285 +236,333 @@
       }
     }
   });
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   var get = Ember.get;
-  
+
   Ember.FilteredRecordArray = Ember.RecordArray.extend({
     init: function() {
-      if (!get(this, 'modelClass')) {
-        throw new Error('FilteredRecordArrays must be created with a modelClass');
+      if (!get(this, "modelClass")) {
+        throw new Error(
+          "FilteredRecordArrays must be created with a modelClass"
+        );
       }
-      if (!get(this, 'filterFunction')) {
-        throw new Error('FilteredRecordArrays must be created with a filterFunction');
+      if (!get(this, "filterFunction")) {
+        throw new Error(
+          "FilteredRecordArrays must be created with a filterFunction"
+        );
       }
-      if (!get(this, 'filterProperties')) {
-        throw new Error('FilteredRecordArrays must be created with filterProperties');
+      if (!get(this, "filterProperties")) {
+        throw new Error(
+          "FilteredRecordArrays must be created with filterProperties"
+        );
       }
-  
-      var modelClass = get(this, 'modelClass');
+
+      var modelClass = get(this, "modelClass");
       modelClass.registerRecordArray(this);
-  
+
       this.registerObservers();
       this.updateFilter();
-  
+
       this._super();
     },
-  
+
     updateFilter: function() {
       var self = this,
-          results = [];
-      get(this, 'modelClass').forEachCachedRecord(function(record) {
+        results = [];
+      get(this, "modelClass").forEachCachedRecord(function(record) {
         if (self.filterFunction(record)) {
           results.push(record);
         }
       });
-      this.set('content', Ember.A(results));
+      this.set("content", Ember.A(results));
     },
-  
+
     updateFilterForRecord: function(record) {
-      var results = get(this, 'content');
+      var results = get(this, "content");
       if (this.filterFunction(record) && !results.includes(record)) {
         results.pushObject(record);
       }
     },
-  
+
     registerObservers: function() {
       var self = this;
-      get(this, 'modelClass').forEachCachedRecord(function(record) {
+      get(this, "modelClass").forEachCachedRecord(function(record) {
         self.registerObserversOnRecord(record);
       });
     },
-  
+
     registerObserversOnRecord: function(record) {
       var self = this,
-          filterProperties = get(this, 'filterProperties');
-  
-      for (var i = 0, l = get(filterProperties, 'length'); i < l; i++) {
-        record.addObserver(filterProperties[i], self, 'updateFilterForRecord');
+        filterProperties = get(this, "filterProperties");
+
+      for (var i = 0, l = get(filterProperties, "length"); i < l; i++) {
+        record.addObserver(filterProperties[i], self, "updateFilterForRecord");
       }
     }
   });
-  
-  
-  })();
-  
-  (function() {
-  
-  var get = Ember.get, set = Ember.set;
-  
+})();
+
+(function() {
+  var get = Ember.get,
+    set = Ember.set;
+
   Ember.ManyArray = Ember.RecordArray.extend({
     _records: null,
     originalContent: null,
     _modifiedRecords: null,
-  
+
     unloadObject: function(record) {
-      var obj = get(this, 'content').findBy('clientId', record._reference.clientId);
-      get(this, 'content').removeObject(obj);
-  
-      var originalObj = get(this, 'originalContent').findBy('clientId', record._reference.clientId);
-      get(this, 'originalContent').removeObject(originalObj);
+      var obj = get(this, "content").findBy(
+        "clientId",
+        record._reference.clientId
+      );
+      get(this, "content").removeObject(obj);
+
+      var originalObj = get(this, "originalContent").findBy(
+        "clientId",
+        record._reference.clientId
+      );
+      get(this, "originalContent").removeObject(originalObj);
     },
-  
-    isDirty: Ember.computed('content.[]', 'originalContent.[]', '_modifiedRecords.[]', function() {
-      var originalContent = get(this, 'originalContent'),
-          originalContentLength = get(originalContent, 'length'),
-          content = get(this, 'content'),
-          contentLength = get(content, 'length');
-  
-      if (originalContentLength !== contentLength) { return true; }
-  
-      if (this._modifiedRecords && this._modifiedRecords.length) { return true; }
-  
-      var isDirty = false;
-  
-      for (var i = 0, l = contentLength; i < l; i++) {
-        if (!originalContent.includes(content[i])) {
-          isDirty = true;
-          break;
+
+    isDirty: Ember.computed(
+      "content.[]",
+      "originalContent.[]",
+      "_modifiedRecords.[]",
+      function() {
+        var originalContent = get(this, "originalContent"),
+          originalContentLength = get(originalContent, "length"),
+          content = get(this, "content"),
+          contentLength = get(content, "length");
+
+        if (originalContentLength !== contentLength) {
+          return true;
         }
+
+        if (this._modifiedRecords && this._modifiedRecords.length) {
+          return true;
+        }
+
+        var isDirty = false;
+
+        for (var i = 0, l = contentLength; i < l; i++) {
+          if (!originalContent.includes(content[i])) {
+            isDirty = true;
+            break;
+          }
+        }
+
+        return isDirty;
       }
-  
-      return isDirty;
-    }),
-  
+    ),
+
     objectAtContent: function(idx) {
-      var content = get(this, 'content');
-  
-      if (!content.length || idx >= content.length) { return; }
-  
+      var content = get(this, "content");
+
+      if (!content.length || idx >= content.length) {
+        return;
+      }
+
       // need to add observer if it wasn't materialized before
-      var observerNeeded = (content[idx].record) ? false : true;
-  
+      var observerNeeded = content[idx].record ? false : true;
+
       var owner = Ember.getOwner(this);
       var record = this.materializeRecord(idx, owner);
-  
+
       if (observerNeeded) {
-        var isDirtyRecord = record.get('isDirty'), isNewRecord = record.get('isNew');
-        if (isDirtyRecord || isNewRecord) { this._modifiedRecords.pushObject(content[idx]); }
-        Ember.addObserver(content[idx], 'record.isDirty', this, 'recordStateChanged');
+        var isDirtyRecord = record.get("isDirty"),
+          isNewRecord = record.get("isNew");
+        if (isDirtyRecord || isNewRecord) {
+          this._modifiedRecords.pushObject(content[idx]);
+        }
+        Ember.addObserver(
+          content[idx],
+          "record.isDirty",
+          this,
+          "recordStateChanged"
+        );
         record.registerParentHasManyArray(this);
       }
-  
+
       return record;
     },
-  
+
     save: function() {
       // TODO: loop over dirty records only
-      return Ember.RSVP.all(this.map(function(record) {
-        return record.save();
-      })).then(Ember.A);
+      return Ember.RSVP.all(
+        this.map(function(record) {
+          return record.save();
+        })
+      ).then(Ember.A);
     },
-  
+
     replaceContent: function(index, removed, added) {
       added = added.map(function(record) {
         return record._reference;
       });
-  
+
       this._super(index, removed, added);
     },
-  
-    _contentDidChange: Ember.observer('content', function() {
-      var content = get(this, 'content');
+
+    _contentDidChange: Ember.observer("content", function() {
+      var content = get(this, "content");
       var contentPrev = this._content;
-  
+
       if (contentPrev && contentPrev !== content) {
-        this.arrayWillChange(contentPrev, 0, get(contentPrev, 'length'), 0);
+        this.arrayWillChange(contentPrev, 0, get(contentPrev, "length"), 0);
         contentPrev.removeArrayObserver(this);
         this._setupOriginalContent(content);
       }
-  
+
       if (content) {
         content.addArrayObserver(this);
-        this.arrayDidChange(content, 0, 0, get(content, 'length'));
+        this.arrayDidChange(content, 0, 0, get(content, "length"));
       }
-  
+
       this._content = content;
     }),
-  
+
     arrayWillChange: function(item, idx, removedCnt, addedCnt) {
       var content = item;
-      for (var i = idx; i < idx+removedCnt; i++) {
+      for (var i = idx; i < idx + removedCnt; i++) {
         var currentItem = content[i];
         if (currentItem && currentItem.record) {
           this._modifiedRecords.removeObject(currentItem);
           currentItem.record.unregisterParentHasManyArray(this);
-          Ember.removeObserver(currentItem, 'record.isDirty', this, 'recordStateChanged');
+          Ember.removeObserver(
+            currentItem,
+            "record.isDirty",
+            this,
+            "recordStateChanged"
+          );
         }
       }
     },
-  
+
     arrayDidChange: function(item, idx, removedCnt, addedCnt) {
-      var parent = get(this, 'parent'), relationshipKey = get(this, 'relationshipKey'),
-          isDirty = get(this, 'isDirty');
-  
+      var parent = get(this, "parent"),
+        relationshipKey = get(this, "relationshipKey"),
+        isDirty = get(this, "isDirty");
+
       var content = item;
-      for (var i = idx; i < idx+addedCnt; i++) {
+      for (var i = idx; i < idx + addedCnt; i++) {
         var currentItem = content[i];
         if (currentItem && currentItem.record) {
-          var isDirtyRecord = currentItem.record.get('isDirty'), isNewRecord = currentItem.record.get('isNew'); // why newly created object is not dirty?
-          if (isDirtyRecord || isNewRecord) { this._modifiedRecords.pushObject(currentItem); }
-          Ember.addObserver(currentItem, 'record.isDirty', this, 'recordStateChanged');
+          var isDirtyRecord = currentItem.record.get("isDirty"),
+            isNewRecord = currentItem.record.get("isNew"); // why newly created object is not dirty?
+          if (isDirtyRecord || isNewRecord) {
+            this._modifiedRecords.pushObject(currentItem);
+          }
+          Ember.addObserver(
+            currentItem,
+            "record.isDirty",
+            this,
+            "recordStateChanged"
+          );
           currentItem.record.registerParentHasManyArray(this);
         }
       }
-  
+
       if (isDirty) {
         parent._relationshipBecameDirty(relationshipKey);
       } else {
         parent._relationshipBecameClean(relationshipKey);
       }
     },
-  
+
     load: function(content) {
       Ember.setProperties(this, {
         content: content,
         originalContent: Ember.A(content.slice())
       });
-      set(this, '_modifiedRecords', Ember.A([]));
+      set(this, "_modifiedRecords", Ember.A([]));
     },
-  
+
     revert: function() {
       this._setupOriginalContent();
     },
-  
+
     _setupOriginalContent: function(content) {
-      content = content || get(this, 'content');
+      content = content || get(this, "content");
       if (content) {
-        set(this, 'originalContent', Ember.A(content.slice()));
+        set(this, "originalContent", Ember.A(content.slice()));
       }
-      set(this, '_modifiedRecords', Ember.A([]));
+      set(this, "_modifiedRecords", Ember.A([]));
     },
-  
+
     init: function() {
       this._super();
       this._setupOriginalContent();
       this._contentDidChange();
     },
-  
+
     recordStateChanged: function(obj, keyName) {
-      var parent = get(this, 'parent'), relationshipKey = get(this, 'relationshipKey');
-  
-      if (obj.record.get('isDirty')) {
-        if (this._modifiedRecords.indexOf(obj) === -1) { this._modifiedRecords.pushObject(obj); }
+      var parent = get(this, "parent"),
+        relationshipKey = get(this, "relationshipKey");
+
+      if (obj.record.get("isDirty")) {
+        if (this._modifiedRecords.indexOf(obj) === -1) {
+          this._modifiedRecords.pushObject(obj);
+        }
         parent._relationshipBecameDirty(relationshipKey);
       } else {
-        if (this._modifiedRecords.indexOf(obj) > -1) { this._modifiedRecords.removeObject(obj); }
-        if (!this.get('isDirty')) {
+        if (this._modifiedRecords.indexOf(obj) > -1) {
+          this._modifiedRecords.removeObject(obj);
+        }
+        if (!this.get("isDirty")) {
           parent._relationshipBecameClean(relationshipKey);
         }
       }
     }
   });
-  
+
   Ember.HasManyArray = Ember.ManyArray.extend({
     materializeRecord: function(idx, owner) {
-      var klass = get(this, 'modelClass'),
-          content = get(this, 'content'),
-          reference = content.objectAt(idx),
-          record = reference.record;
-  
+      var klass = get(this, "modelClass"),
+        content = get(this, "content"),
+        reference = content.objectAt(idx),
+        record = reference.record;
+
       if (record) {
         Ember.setOwner(record, owner);
         return record;
       }
       return klass._findFetchById(reference.id, false, owner);
     },
-  
+
     toJSON: function() {
-      var ids = [], content = this.get('content');
-  
+      var ids = [],
+        content = this.get("content");
+
       content.forEach(function(reference) {
         if (reference.id) {
           ids.push(reference.id);
         }
       });
-  
+
       return ids;
     }
   });
-  
+
   Ember.EmbeddedHasManyArray = Ember.ManyArray.extend({
     create: function(attrs) {
-      var klass = get(this, 'modelClass'),
-          record = klass.create(attrs);
-  
+      var klass = get(this, "modelClass"),
+        record = klass.create(attrs);
+
       this.pushObject(record);
-  
+
       return record; // FIXME: inject parent's id
     },
-  
+
     materializeRecord: function(idx, owner) {
-      var klass = get(this, 'modelClass'),
-          primaryKey = get(klass, 'primaryKey'),
-          content = get(this, 'content'),
-          reference = content.objectAt(idx),
-          attrs = reference.data;
-  
+      var klass = get(this, "modelClass"),
+        primaryKey = get(klass, "primaryKey"),
+        content = get(this, "content"),
+        reference = content.objectAt(idx),
+        attrs = reference.data;
+
       var record;
       if (reference.record) {
         record = reference.record;
@@ -503,241 +570,265 @@
         record = klass.create({ _reference: reference });
         reference.record = record;
         Ember.setOwner(record, owner);
-  
+
         if (attrs) {
           record.load(attrs[primaryKey], attrs);
         }
       }
-  
+
       return record;
     },
-  
+
     toJSON: function() {
       return this.map(function(record) {
         return record.toJSON();
       });
     }
   });
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
+  var __EMBER_METAL__ = Ember.__loader.require("@ember/-internals/metal");
+
   var get = Ember.get,
-      set = Ember.set,
-      setProperties = Ember.setProperties,
-      meta = Ember.meta,
-      underscore = Ember.String.underscore;
-  
+    set = Ember.set,
+    setProperties = Ember.setProperties,
+    meta = Ember.meta,
+    underscore = Ember.String.underscore;
+
   function contains(array, element) {
     for (var i = 0, l = array.length; i < l; i++) {
-      if (array[i] === element) { return true; }
+      if (array[i] === element) {
+        return true;
+      }
     }
     return false;
   }
-  
+
   function concatUnique(toArray, fromArray) {
     var e;
     for (var i = 0, l = fromArray.length; i < l; i++) {
       e = fromArray[i];
-      if (!contains(toArray, e)) { toArray.push(e); }
+      if (!contains(toArray, e)) {
+        toArray.push(e);
+      }
     }
     return toArray;
   }
-  
+
   function hasCachedValue(object, key) {
     var objectMeta = meta(object, false);
     if (objectMeta) {
       return key in objectMeta.cache;
     }
   }
-  
+
   function isDescriptor(value) {
-    // Ember < 1.11
-    if (Ember.Descriptor !== undefined) {
-      return value instanceof Ember.Descriptor;
+    if (__EMBER_METAL__.isClassicDecorator) {
+      return __EMBER_METAL__.isClassicDecorator(value);
+    } else {
+      return (
+        value &&
+        (typeof value === "object" || typeof value === "function") &&
+        value.isDescriptor
+      );
     }
-    // Ember >= 1.11
-    return value && typeof value === 'object' && value.isDescriptor;
   }
-  
-  Ember.run.backburner.queueNames.push('data');
-  
+
+  Ember.run.backburner.queueNames.push("data");
+
   Ember.Model = Ember.Object.extend(Ember.Evented, {
     isLoaded: true,
-    isLoading: Ember.computed.not('isLoaded'),
+    isLoading: Ember.computed.not("isLoaded"),
     isNew: true,
     isDeleted: false,
     _dirtyAttributes: null,
-  
+
     /**
-      Called when attribute is accessed.
-  
-      @method getAttr
-      @param key {String} key which is being accessed
-      @param value {Object} value, which will be returned from getter by default
-    */
+    Called when attribute is accessed.
+
+    @method getAttr
+    @param key {String} key which is being accessed
+    @param value {Object} value, which will be returned from getter by default
+  */
     getAttr: function(key, value) {
       return value;
     },
-  
-    isDirty: Ember.computed('_dirtyAttributes.length', function() {
-      var dirtyAttributes = get(this, '_dirtyAttributes');
-      return dirtyAttributes && dirtyAttributes.length !== 0 || false;
+
+    isDirty: Ember.computed("_dirtyAttributes.length", function() {
+      var dirtyAttributes = get(this, "_dirtyAttributes");
+      return (dirtyAttributes && dirtyAttributes.length !== 0) || false;
     }),
-  
+
     _relationshipBecameDirty: function(name) {
-      var dirtyAttributes = get(this, '_dirtyAttributes');
+      var dirtyAttributes = get(this, "_dirtyAttributes");
       if (dirtyAttributes) {
-          dirtyAttributes.addObject(name);
+        dirtyAttributes.addObject(name);
       } else {
-          set(this, '_dirtyAttributes', Ember.A([name]));
+        set(this, "_dirtyAttributes", Ember.A([name]));
       }
     },
-  
+
     _relationshipBecameClean: function(name) {
-      var dirtyAttributes = get(this, '_dirtyAttributes');
-      if (dirtyAttributes) { dirtyAttributes.removeObject(name); }
+      var dirtyAttributes = get(this, "_dirtyAttributes");
+      if (dirtyAttributes) {
+        dirtyAttributes.removeObject(name);
+      }
     },
-  
+
     dataKey: function(key) {
       return this.constructor.dataKey(key);
     },
-  
+
     init: function() {
       this._createReference();
       if (!this._dirtyAttributes) {
-        set(this, '_dirtyAttributes', Ember.A([]));
+        set(this, "_dirtyAttributes", Ember.A([]));
       }
       this._super();
     },
-  
+
     _createReference: function() {
       var reference = this._reference,
-          id = this.getPrimaryKey();
-  
+        id = this.getPrimaryKey();
+
       if (!reference) {
         reference = this.constructor._getOrCreateReferenceForId(id);
-        set(reference, 'record', this);
+        set(reference, "record", this);
         this._reference = reference;
       } else if (reference.id !== id) {
         reference.id = id;
         this.constructor._cacheReference(reference);
       }
-  
+
       if (!reference.id) {
         reference.id = id;
       }
-  
+
       return reference;
     },
-  
+
     getPrimaryKey: function() {
-      return get(this, get(this.constructor, 'primaryKey'));
+      return get(this, get(this.constructor, "primaryKey"));
     },
-  
+
     load: function(id, hash) {
       var data = {};
-      data[get(this.constructor, 'primaryKey')] = id;
-      set(this, '_data', Ember.merge(data, hash));
-      this.getWithDefault('_dirtyAttributes', Ember.A([])).clear();
-  
+      data[get(this.constructor, "primaryKey")] = id;
+      set(this, "_data", Ember.assign(data, hash));
+      this.getWithDefault("_dirtyAttributes", Ember.A([])).clear();
+
       this._reloadHasManys();
-  
+
       // eagerly load embedded data
-      var relationships = this.constructor._relationships || [], meta = Ember.meta(this), relationshipKey, relationship, relationshipMeta, relationshipData, relationshipType;
+      var relationships = this.constructor._relationships || [],
+        meta = Ember.meta(this),
+        relationshipKey,
+        relationship,
+        relationshipMeta,
+        relationshipData,
+        relationshipType;
       for (var i = 0, l = relationships.length; i < l; i++) {
         relationshipKey = relationships[i];
         relationshipMeta = this.constructor.metaForProperty(relationshipKey);
-  
+
         if (relationshipMeta.options.embedded) {
           relationshipType = relationshipMeta.type;
           if (typeof relationshipType === "string") {
-            relationshipType = Ember.get(Ember.lookup, relationshipType) || Ember.getOwner(this).resolveRegistration('model:'+ relationshipType);
+            relationshipType =
+              Ember.get(Ember.lookup, relationshipType) ||
+              Ember.getOwner(this).resolveRegistration(
+                "model:" + relationshipType
+              );
           }
-  
+
           relationshipData = data[relationshipKey];
           if (relationshipData) {
             relationshipType.load(relationshipData);
           }
         }
       }
-  
-      set(this, 'isNew', false);
-      set(this, 'isLoaded', true);
+
+      set(this, "isNew", false);
+      set(this, "isLoaded", true);
       this._createReference();
-      this.trigger('didLoad');
+      this.trigger("didLoad");
     },
-  
+
     didDefineProperty: function(proto, key, value) {
       if (isDescriptor(value)) {
         var meta = value.meta();
         var klass = proto.constructor;
-  
+
         if (meta.isAttribute) {
-          if (!klass._attributes) { klass._attributes = []; }
+          if (!klass._attributes) {
+            klass._attributes = [];
+          }
           klass._attributes.push(key);
         } else if (meta.isRelationship) {
-          if (!klass._relationships) { klass._relationships = []; }
+          if (!klass._relationships) {
+            klass._relationships = [];
+          }
           klass._relationships.push(key);
           meta.relationshipKey = key;
         }
       }
     },
-  
+
     serializeHasMany: function(key, meta) {
       return this.get(key).toJSON();
     },
-  
+
     serializeBelongsTo: function(key, meta) {
       if (meta.options.embedded) {
         var record = this.get(key);
         return record ? record.toJSON() : null;
       } else {
-        var primaryKey = get(meta.getType(this), 'primaryKey');
-        return this.get(key + '.' + primaryKey);
+        var primaryKey = get(meta.getType(this), "primaryKey");
+        return this.get(key + "." + primaryKey);
       }
     },
-  
+
     toJSON: function() {
-      var key, meta,
-          json = {},
-          attributes = this.constructor.getAttributes(),
-          relationships = this.constructor.getRelationships(),
-          properties = attributes ? this.getProperties(attributes) : {},
-          rootKey = get(this.constructor, 'rootKey');
-  
+      var key,
+        meta,
+        json = {},
+        attributes = this.constructor.getAttributes(),
+        relationships = this.constructor.getRelationships(),
+        properties = attributes ? this.getProperties(attributes) : {},
+        rootKey = get(this.constructor, "rootKey");
+
       for (key in properties) {
         meta = this.constructor.metaForProperty(key);
         if (meta.type && meta.type.serialize) {
           json[this.dataKey(key)] = meta.type.serialize(properties[key]);
         } else if (meta.type && Ember.Model.dataTypes[meta.type]) {
-          json[this.dataKey(key)] = Ember.Model.dataTypes[meta.type].serialize(properties[key]);
+          json[this.dataKey(key)] = Ember.Model.dataTypes[meta.type].serialize(
+            properties[key]
+          );
         } else {
           json[this.dataKey(key)] = properties[key];
         }
       }
-  
+
       if (relationships) {
         var data, relationshipKey;
-  
-        for(var i = 0; i < relationships.length; i++) {
+
+        for (var i = 0; i < relationships.length; i++) {
           key = relationships[i];
           meta = this.constructor.metaForProperty(key);
           relationshipKey = meta.options.key || key;
-  
-          if (meta.kind === 'belongsTo') {
+
+          if (meta.kind === "belongsTo") {
             data = this.serializeBelongsTo(key, meta);
           } else {
             data = this.serializeHasMany(key, meta);
           }
-  
+
           json[relationshipKey] = data;
-  
         }
       }
-  
+
       if (rootKey) {
         var jsonRoot = {};
         jsonRoot[rootKey] = json;
@@ -746,82 +837,90 @@
         return json;
       }
     },
-  
+
     save: function() {
       var adapter = this.constructor.adapter;
-      set(this, 'isSaving', true);
-      if (get(this, 'isNew')) {
+      set(this, "isSaving", true);
+      if (get(this, "isNew")) {
         return adapter.createRecord(this);
-      } else if (get(this, 'isDirty')) {
+      } else if (get(this, "isDirty")) {
         return adapter.saveRecord(this);
-      } else { // noop, return a resolved promise
+      } else {
+        // noop, return a resolved promise
         var self = this,
-            promise = new Ember.RSVP.Promise(function(resolve, reject) {
-              resolve(self);
-            });
-        set(this, 'isSaving', false);
+          promise = new Ember.RSVP.Promise(function(resolve, reject) {
+            resolve(self);
+          });
+        set(this, "isSaving", false);
         return promise;
       }
     },
-  
+
     reload: function() {
-      this.getWithDefault('_dirtyAttributes', Ember.A([])).clear();
-      return this.constructor.reload(this.get(get(this.constructor, 'primaryKey')), Ember.getOwner(this));
+      this.getWithDefault("_dirtyAttributes", Ember.A([])).clear();
+      return this.constructor.reload(
+        this.get(get(this.constructor, "primaryKey")),
+        Ember.getOwner(this)
+      );
     },
-  
+
     revert: function() {
-      this.getWithDefault('_dirtyAttributes', Ember.A([])).clear();
-      this.notifyPropertyChange('_data');
+      this.getWithDefault("_dirtyAttributes", Ember.A([])).clear();
+      this.notifyPropertyChange("_data");
       this._reloadHasManys(true);
     },
-  
+
     didCreateRecord: function() {
-      var primaryKey = get(this.constructor, 'primaryKey'),
-          id = get(this, primaryKey);
-  
-      set(this, 'isNew', false);
-  
-      set(this, '_dirtyAttributes', Ember.A([]));
+      var primaryKey = get(this.constructor, "primaryKey"),
+        id = get(this, primaryKey);
+
+      set(this, "isNew", false);
+
+      set(this, "_dirtyAttributes", Ember.A([]));
       this.constructor.addToRecordArrays(this);
-      this.trigger('didCreateRecord');
+      this.trigger("didCreateRecord");
       this.didSaveRecord();
     },
-  
+
     didSaveRecord: function() {
-      set(this, 'isSaving', false);
-      this.trigger('didSaveRecord');
-      if (this.get('isDirty')) { this._copyDirtyAttributesToData(); }
+      set(this, "isSaving", false);
+      this.trigger("didSaveRecord");
+      if (this.get("isDirty")) {
+        this._copyDirtyAttributesToData();
+      }
     },
-  
+
     deleteRecord: function() {
       return this.constructor.adapter.deleteRecord(this);
     },
-  
+
     didDeleteRecord: function() {
       this.constructor.removeFromRecordArrays(this);
-      set(this, 'isDeleted', true);
-      this.trigger('didDeleteRecord');
+      set(this, "isDeleted", true);
+      this.trigger("didDeleteRecord");
     },
-  
+
     _copyDirtyAttributesToData: function() {
-      if (!this._dirtyAttributes) { return; }
+      if (!this._dirtyAttributes) {
+        return;
+      }
       var dirtyAttributes = this._dirtyAttributes,
-          data = get(this, '_data'),
-          key;
-  
+        data = get(this, "_data"),
+        key;
+
       if (!data) {
         data = {};
-        set(this, '_data', data);
+        set(this, "_data", data);
       }
       for (var i = 0, l = dirtyAttributes.length; i < l; i++) {
         // TODO: merge Object.create'd object into prototype
         key = dirtyAttributes[i];
         data[this.dataKey(key)] = this.cacheFor(key);
       }
-      set(this, '_dirtyAttributes', Ember.A([]));
+      set(this, "_dirtyAttributes", Ember.A([]));
       this._resetDirtyStateInNestedObjects(this); // we need to reset isDirty state to all child objects in embedded relationships
     },
-  
+
     _resetDirtyStateInNestedObjects: function(object) {
       var i, obj;
       if (object._hasManyArrays) {
@@ -829,14 +928,14 @@
           var array = object._hasManyArrays[i];
           array.revert();
           if (array.embedded) {
-            for (var j = 0; j < array.get('length'); j++) {
+            for (var j = 0; j < array.get("length"); j++) {
               obj = array.objectAt(j);
               obj._copyDirtyAttributesToData();
             }
           }
         }
       }
-  
+
       if (object._belongsTo) {
         for (i = 0; i < object._belongsTo.length; i++) {
           var belongsTo = object._belongsTo[i];
@@ -849,34 +948,49 @@
         }
       }
     },
-  
+
     _registerHasManyArray: function(array) {
-      if (!this._hasManyArrays) { this._hasManyArrays = Ember.A([]); }
-  
+      if (!this._hasManyArrays) {
+        this._hasManyArrays = Ember.A([]);
+      }
+
       this._hasManyArrays.pushObject(array);
     },
-  
+
     registerParentHasManyArray: function(array) {
-      if (!this._parentHasManyArrays) { this._parentHasManyArrays = Ember.A([]); }
-  
+      if (!this._parentHasManyArrays) {
+        this._parentHasManyArrays = Ember.A([]);
+      }
+
       this._parentHasManyArrays.pushObject(array);
     },
-  
+
     unregisterParentHasManyArray: function(array) {
-      if (!this._parentHasManyArrays) { return; }
-  
+      if (!this._parentHasManyArrays) {
+        return;
+      }
+
       this._parentHasManyArrays.removeObject(array);
     },
-  
+
     _reloadHasManys: function(reverting) {
-      if (!this._hasManyArrays) { return; }
+      if (!this._hasManyArrays) {
+        return;
+      }
       var i, j;
       for (i = 0; i < this._hasManyArrays.length; i++) {
         var array = this._hasManyArrays[i],
-            hasManyContent = this._getHasManyContent(get(array, 'key'), get(array, 'modelClass'), get(array, 'embedded'));
+          hasManyContent = this._getHasManyContent(
+            get(array, "key"),
+            get(array, "modelClass"),
+            get(array, "embedded")
+          );
         if (!reverting) {
-          for (j = 0; j < array.get('length'); j++) {
-            if (array.objectAt(j).get('isNew') && !array.objectAt(j).get('isDeleted')) {
+          for (j = 0; j < array.get("length"); j++) {
+            if (
+              array.objectAt(j).get("isNew") &&
+              !array.objectAt(j).get("isDeleted")
+            ) {
               hasManyContent.addObject(array.objectAt(j)._reference);
             }
           }
@@ -884,146 +998,161 @@
         array.load(hasManyContent);
       }
     },
-  
+
     _getHasManyContent: function(key, type, embedded) {
-      var content = get(this, '_data.' + key);
-  
+      var content = get(this, "_data." + key);
+
       if (content) {
         var mapFunction, primaryKey, reference;
         if (embedded) {
-          primaryKey = get(type, 'primaryKey');
+          primaryKey = get(type, "primaryKey");
           mapFunction = function(attrs) {
             reference = type._getOrCreateReferenceForId(attrs[primaryKey]);
             reference.data = attrs;
             return reference;
           };
         } else {
-          mapFunction = function(id) { return type._getOrCreateReferenceForId(id); };
+          mapFunction = function(id) {
+            return type._getOrCreateReferenceForId(id);
+          };
         }
         content = content.map(mapFunction);
       }
-  
+
       return Ember.A(content || []);
     },
-  
+
     _registerBelongsTo: function(key) {
-      if (!this._belongsTo) { this._belongsTo = Ember.A([]); }
-  
+      if (!this._belongsTo) {
+        this._belongsTo = Ember.A([]);
+      }
+
       this._belongsTo.pushObject(key);
     }
   });
-  
+
   Ember.Model.reopenClass({
-    primaryKey: 'id',
-  
+    primaryKey: "id",
+
+    _isDescriptor: isDescriptor,
+
     create: function(properties) {
       var transformedProperties = {};
       if (properties) {
         var attributes = this.getAttributes();
-  
-        for (var i=0; i<attributes.length; i++) {
+
+        for (var i = 0; i < attributes.length; i++) {
           var attribute = attributes[i];
           var transformedKey = this.dataKey(attribute);
           transformedProperties[transformedKey] = properties[attribute];
         }
       }
-  
+
       var obj = this._super.apply(this, arguments);
-      obj.set('_data', transformedProperties);
+      obj.set("_data", transformedProperties);
       obj.setProperties(properties);
       return obj;
     },
-  
+
     dataKey: function(key) {
       var meta = this.metaForProperty(key);
       if (meta.options && meta.options.key) {
-        return this.camelizeKeys ? underscore(meta.options.key) : meta.options.key;
+        return this.camelizeKeys
+          ? underscore(meta.options.key)
+          : meta.options.key;
       }
       return this.camelizeKeys ? underscore(key) : key;
     },
-  
+
     adapter: Ember.Adapter.create(),
-  
+
     _clientIdCounter: 1,
-  
+
     getAttributes: function() {
       this.proto(); // force class "compilation" if it hasn't been done.
       var attributes = this._attributes || [];
-      if (typeof this.superclass.getAttributes === 'function') {
+      if (typeof this.superclass.getAttributes === "function") {
         attributes = this.superclass.getAttributes().concat(attributes);
       }
       return attributes;
     },
-  
+
     getRelationships: function() {
       this.proto(); // force class "compilation" if it hasn't been done.
       var relationships = this._relationships || [];
-      if (typeof this.superclass.getRelationships === 'function') {
-        relationships = this.superclass.getRelationships().concat(relationships);
+      if (typeof this.superclass.getRelationships === "function") {
+        relationships = this.superclass
+          .getRelationships()
+          .concat(relationships);
       }
       return relationships;
     },
-  
+
     fetch: function(id) {
       if (!arguments.length) {
         return this._findFetchAll(true);
       } else if (Ember.isArray(id)) {
         return this._findFetchMany(id, true);
-      } else if (typeof id === 'object') {
+      } else if (typeof id === "object") {
         return this._findFetchQuery(id, true);
       } else {
         return this._findFetchById(id, true);
       }
     },
-  
+
     find: function(id) {
       if (!arguments.length) {
         return this._findFetchAll(false);
       } else if (Ember.isArray(id)) {
         return this._findFetchMany(id, false);
-      } else if (typeof id === 'object') {
+      } else if (typeof id === "object") {
         return this._findFetchQuery(id, false);
       } else {
         return this._findFetchById(id, false);
       }
     },
-  
+
     findQuery: function(params) {
       return this._findFetchQuery(params, false);
     },
-  
+
     fetchQuery: function(params) {
       return this._findFetchQuery(params, true);
     },
-  
+
     _findFetchQuery: function(params, isFetch, owner) {
-      var records = Ember.RecordArray.create({modelClass: this, _query: params});
+      var records = Ember.RecordArray.create({
+        modelClass: this,
+        _query: params
+      });
       Ember.setOwner(records, owner);
-  
+
       var promise = this.adapter.findQuery(this, records, params);
-  
+
       return isFetch ? promise : records;
     },
-  
+
     findMany: function(ids) {
       return this._findFetchMany(ids, false);
     },
-  
+
     fetchMany: function(ids) {
       return this._findFetchMany(ids, true);
     },
-  
+
     _findFetchMany: function(ids, isFetch, owner) {
       Ember.assert("findFetchMany requires an array", Ember.isArray(ids));
-  
-      var records = Ember.RecordArray.create({_ids: ids, modelClass: this}),
-          deferred;
-  
+
+      var records = Ember.RecordArray.create({ _ids: ids, modelClass: this }),
+        deferred;
+
       Ember.setOwner(records, owner);
-  
-      if (!this.recordArrays) { this.recordArrays = []; }
+
+      if (!this.recordArrays) {
+        this.recordArrays = [];
+      }
       this.recordArrays.push(records);
-  
+
       if (this._currentBatchIds) {
         concatUnique(this._currentBatchIds, ids);
         this._currentBatchRecordArrays.push(records);
@@ -1031,31 +1160,33 @@
         this._currentBatchIds = concatUnique([], ids);
         this._currentBatchRecordArrays = [records];
       }
-  
+
       if (isFetch) {
         deferred = Ember.RSVP.defer();
-        Ember.set(deferred, 'resolveWith', records);
-  
-        if (!this._currentBatchDeferreds) { this._currentBatchDeferreds = []; }
+        Ember.set(deferred, "resolveWith", records);
+
+        if (!this._currentBatchDeferreds) {
+          this._currentBatchDeferreds = [];
+        }
         this._currentBatchDeferreds.push(deferred);
       }
-  
-      Ember.run.scheduleOnce('data', this, this._executeBatch, owner);
-  
+
+      Ember.run.scheduleOnce("data", this, this._executeBatch, owner);
+
       return isFetch ? deferred.promise : records;
     },
-  
+
     findAll: function() {
       return this._findFetchAll(false);
     },
-  
+
     fetchAll: function() {
       return this._findFetchAll(true);
     },
-  
+
     _findFetchAll: function(isFetch, owner) {
       var self = this;
-  
+
       var currentFetchPromise = this._currentFindFetchAllPromise;
       if (isFetch && currentFetchPromise) {
         return currentFetchPromise;
@@ -1068,16 +1199,21 @@
           return this._findAllRecordArray;
         }
       }
-  
-      var records = this._findAllRecordArray = Ember.RecordArray.create({modelClass: this});
+
+      var records = (this._findAllRecordArray = Ember.RecordArray.create({
+        modelClass: this
+      }));
       Ember.setOwner(records, owner);
-  
-      var promise = this._currentFindFetchAllPromise = this.adapter.findAll(this, records);
-  
-      promise['finally'](function() {
+
+      var promise = (this._currentFindFetchAllPromise = this.adapter.findAll(
+        this,
+        records
+      ));
+
+      promise["finally"](function() {
         self._currentFindFetchAllPromise = null;
       });
-  
+
       // Remove the cached record array if the promise is rejected
       if (promise.then) {
         promise.then(null, function() {
@@ -1085,24 +1221,24 @@
           return Ember.RSVP.reject.apply(null, arguments);
         });
       }
-  
+
       return isFetch ? promise : records;
     },
-  
+
     findById: function(id) {
       return this._findFetchById(id, false);
     },
-  
+
     fetchById: function(id) {
       return this._findFetchById(id, true);
     },
-  
+
     _findFetchById: function(id, isFetch, owner) {
       var record = this.cachedRecordForId(id, owner),
-          isLoaded = get(record, 'isLoaded'),
-          adapter = get(this, 'adapter'),
-          deferredOrPromise;
-  
+        isLoaded = get(record, "isLoaded"),
+        adapter = get(this, "adapter"),
+        deferredOrPromise;
+
       if (isLoaded) {
         if (isFetch) {
           return new Ember.RSVP.Promise(function(resolve, reject) {
@@ -1112,125 +1248,140 @@
           return record;
         }
       }
-  
+
       deferredOrPromise = this._fetchById(record, id);
-  
+
       return isFetch ? deferredOrPromise : record;
     },
-  
+
     _currentBatchIds: null,
     _currentBatchRecordArrays: null,
     _currentBatchDeferreds: null,
-  
+
     reload: function(id, owner) {
       var record = this.cachedRecordForId(id, owner);
-      record.set('isLoaded', false);
+      record.set("isLoaded", false);
       return this._fetchById(record, id);
     },
-  
+
     _fetchById: function(record, id) {
-      var adapter = get(this, 'adapter'),
-          deferred;
-  
+      var adapter = get(this, "adapter"),
+        deferred;
+
       if (adapter.findMany && !adapter.findMany.isUnimplemented) {
         if (this._currentBatchIds) {
-          if (!contains(this._currentBatchIds, id)) { this._currentBatchIds.push(id); }
+          if (!contains(this._currentBatchIds, id)) {
+            this._currentBatchIds.push(id);
+          }
         } else {
           this._currentBatchIds = [id];
           this._currentBatchRecordArrays = [];
         }
-  
+
         deferred = Ember.RSVP.defer();
-  
+
         //Attached the record to the deferred so we can resolve it later.
-        Ember.set(deferred, 'resolveWith', record);
-  
-        if (!this._currentBatchDeferreds) { this._currentBatchDeferreds = []; }
+        Ember.set(deferred, "resolveWith", record);
+
+        if (!this._currentBatchDeferreds) {
+          this._currentBatchDeferreds = [];
+        }
         this._currentBatchDeferreds.push(deferred);
-  
+
         var owner = Ember.getOwner(record);
-        Ember.run.scheduleOnce('data', this, this._executeBatch, owner);
-  
+        Ember.run.scheduleOnce("data", this, this._executeBatch, owner);
+
         return deferred.promise;
       } else {
         return adapter.find(record, id);
       }
     },
-  
+
     _executeBatch: function(owner) {
       var batchIds = this._currentBatchIds,
-          batchRecordArrays = this._currentBatchRecordArrays,
-          batchDeferreds = this._currentBatchDeferreds,
-          self = this,
-          requestIds = [],
-          promise,
-          i;
-  
+        batchRecordArrays = this._currentBatchRecordArrays,
+        batchDeferreds = this._currentBatchDeferreds,
+        self = this,
+        requestIds = [],
+        promise,
+        i;
+
       this._currentBatchIds = null;
       this._currentBatchRecordArrays = null;
       this._currentBatchDeferreds = null;
-  
+
       for (i = 0; i < batchIds.length; i++) {
-        if (!this.cachedRecordForId(batchIds[i], owner).get('isLoaded')) {
+        if (!this.cachedRecordForId(batchIds[i], owner).get("isLoaded")) {
           requestIds.push(batchIds[i]);
         }
       }
-  
+
       if (requestIds.length === 1) {
-        promise = get(this, 'adapter').find(this.cachedRecordForId(requestIds[0], owner), requestIds[0]);
+        promise = get(this, "adapter").find(
+          this.cachedRecordForId(requestIds[0], owner),
+          requestIds[0]
+        );
       } else {
-        var recordArray = Ember.RecordArray.create({_ids: batchIds });
+        var recordArray = Ember.RecordArray.create({ _ids: batchIds });
         Ember.setOwner(recordArray, owner);
         if (requestIds.length === 0) {
-          promise = new Ember.RSVP.Promise(function(resolve, reject) { resolve(recordArray); });
+          promise = new Ember.RSVP.Promise(function(resolve, reject) {
+            resolve(recordArray);
+          });
           recordArray.notifyLoaded();
         } else {
-          promise = get(this, 'adapter').findMany(this, recordArray, requestIds);
+          promise = get(this, "adapter").findMany(
+            this,
+            recordArray,
+            requestIds
+          );
         }
       }
-  
-      promise.then(function() {
-        for (var i = 0, l = batchRecordArrays.length; i < l; i++) {
-          batchRecordArrays[i].loadForFindMany(self);
-        }
-  
-        if (batchDeferreds) {
-          for (i = 0, l = batchDeferreds.length; i < l; i++) {
-            var resolveWith = Ember.get(batchDeferreds[i], 'resolveWith');
-            batchDeferreds[i].resolve(resolveWith);
+
+      promise
+        .then(function() {
+          for (var i = 0, l = batchRecordArrays.length; i < l; i++) {
+            batchRecordArrays[i].loadForFindMany(self);
           }
-        }
-      }).then(null, function(errorXHR) {
-        if (batchDeferreds) {
-          for (var i = 0, l = batchDeferreds.length; i < l; i++) {
-            batchDeferreds[i].reject(errorXHR);
+
+          if (batchDeferreds) {
+            for (i = 0, l = batchDeferreds.length; i < l; i++) {
+              var resolveWith = Ember.get(batchDeferreds[i], "resolveWith");
+              batchDeferreds[i].resolve(resolveWith);
+            }
           }
-        }
-      });
+        })
+        .then(null, function(errorXHR) {
+          if (batchDeferreds) {
+            for (var i = 0, l = batchDeferreds.length; i < l; i++) {
+              batchDeferreds[i].reject(errorXHR);
+            }
+          }
+        });
     },
-  
-    getCachedReferenceRecord: function(id){
+
+    getCachedReferenceRecord: function(id) {
       var ref = this._getReferenceById(id);
-      if(ref && ref.record) {
+      if (ref && ref.record) {
         return ref.record;
       }
       return undefined;
     },
-  
+
     cachedRecordForId: function(id, owner) {
       var record;
       if (!this.transient) {
         record = this.getCachedReferenceRecord(id);
       }
-  
+
       if (!record) {
-        var primaryKey = get(this, 'primaryKey'),
-            attrs = {isLoaded: false};
-  
+        var primaryKey = get(this, "primaryKey"),
+          attrs = { isLoaded: false };
+
         attrs[primaryKey] = id;
         record = this.create(attrs);
         Ember.setOwner(record, owner);
-  
+
         if (!this.transient) {
           var sideloadedData = this.sideloadedData && this.sideloadedData[id];
           if (sideloadedData) {
@@ -1238,11 +1389,10 @@
           }
         }
       }
-  
+
       return record;
     },
-  
-  
+
     addToRecordArrays: function(record) {
       if (this._findAllRecordArray) {
         this._findAllRecordArray.addObject(record);
@@ -1258,29 +1408,29 @@
         });
       }
     },
-  
-    unload: function (record) {
+
+    unload: function(record) {
       this.removeFromHasManyArrays(record);
       this.removeFromRecordArrays(record);
-      var primaryKey = record.get(get(this, 'primaryKey'));
+      var primaryKey = record.get(get(this, "primaryKey"));
       this.removeFromCache(primaryKey);
     },
-  
-    clearCache: function () {
+
+    clearCache: function() {
       this.sideloadedData = undefined;
       this._referenceCache = undefined;
       this._findAllRecordArray = undefined;
     },
-  
-    removeFromCache: function (key) {
+
+    removeFromCache: function(key) {
       if (this.sideloadedData && this.sideloadedData[key]) {
         delete this.sideloadedData[key];
       }
-      if(this._referenceCache && this._referenceCache[key]) {
+      if (this._referenceCache && this._referenceCache[key]) {
         delete this._referenceCache[key];
       }
     },
-  
+
     removeFromHasManyArrays: function(record) {
       if (record._parentHasManyArrays) {
         record._parentHasManyArrays.forEach(function(hasManyArray) {
@@ -1289,7 +1439,7 @@
         record._parentHasManyArrays = null;
       }
     },
-  
+
     removeFromRecordArrays: function(record) {
       if (this._findAllRecordArray) {
         this._findAllRecordArray.removeObject(record);
@@ -1300,49 +1450,61 @@
         });
       }
     },
-  
+
     // FIXME
     findFromCacheOrLoad: function(data, owner) {
       var record;
-      if (!data[get(this, 'primaryKey')]) {
-        record = this.create({isLoaded: false});
+      if (!data[get(this, "primaryKey")]) {
+        record = this.create({ isLoaded: false });
       } else {
-        record = this.cachedRecordForId(data[get(this, 'primaryKey')], owner);
+        record = this.cachedRecordForId(data[get(this, "primaryKey")], owner);
       }
-      record.load(data[get(this, 'primaryKey')], data);
+      record.load(data[get(this, "primaryKey")], data);
       Ember.setOwner(record, owner);
-  
+
       return record;
     },
-  
+
     registerRecordArray: function(recordArray) {
-      if (!this.recordArrays) { this.recordArrays = []; }
+      if (!this.recordArrays) {
+        this.recordArrays = [];
+      }
       this.recordArrays.push(recordArray);
     },
-  
+
     unregisterRecordArray: function(recordArray) {
-      if (!this.recordArrays) { return; }
+      if (!this.recordArrays) {
+        return;
+      }
       Ember.A(this.recordArrays).removeObject(recordArray);
     },
-  
+
     forEachCachedRecord: function(callback) {
-      if (!this._referenceCache) { return; }
+      if (!this._referenceCache) {
+        return;
+      }
       var ids = Object.keys(this._referenceCache);
-      ids.map(function(id) {
-        return this._getReferenceById(id).record;
-      }, this).forEach(callback);
+      ids
+        .map(function(id) {
+          return this._getReferenceById(id).record;
+        }, this)
+        .forEach(callback);
     },
-  
+
     load: function(hashes) {
-      if (Ember.typeOf(hashes) !== 'array') { hashes = [hashes]; }
-  
-      if (!this.sideloadedData) { this.sideloadedData = {}; }
-  
+      if (Ember.typeOf(hashes) !== "array") {
+        hashes = [hashes];
+      }
+
+      if (!this.sideloadedData) {
+        this.sideloadedData = {};
+      }
+
       for (var i = 0, l = hashes.length; i < l; i++) {
         var hash = hashes[i],
-            primaryKey = hash[get(this, 'primaryKey')],
-            record = this.getCachedReferenceRecord(primaryKey);
-  
+          primaryKey = hash[get(this, "primaryKey")],
+          record = this.getCachedReferenceRecord(primaryKey);
+
         if (record) {
           record.load(primaryKey, hash);
         } else {
@@ -1350,40 +1512,53 @@
         }
       }
     },
-  
+
     _getReferenceById: function(id) {
-      if (!this._referenceCache) { this._referenceCache = {}; }
+      if (!this._referenceCache) {
+        this._referenceCache = {};
+      }
       return this._referenceCache[id];
     },
-  
+
     _getOrCreateReferenceForId: function(id) {
       var reference = this._getReferenceById(id);
-  
+
       if (!reference) {
         reference = this._createReference(id);
       }
-  
+
       return reference;
     },
-  
+
     _createReference: function(id) {
-      if (!this._referenceCache) { this._referenceCache = {}; }
-  
-      Ember.assert('The id ' + id + ' has already been used with another record of type ' + this.toString() + '.', !id || !this._referenceCache[id]);
-  
+      if (!this._referenceCache) {
+        this._referenceCache = {};
+      }
+
+      Ember.assert(
+        "The id " +
+          id +
+          " has already been used with another record of type " +
+          this.toString() +
+          ".",
+        !id || !this._referenceCache[id]
+      );
+
       var reference = {
         id: id,
         clientId: this._clientIdCounter++
       };
-  
+
       this._cacheReference(reference);
-  
+
       return reference;
     },
-  
+
     _cacheReference: function(reference) {
-      if (!this._referenceCache) { this._referenceCache = {}; }
-  
+      if (!this._referenceCache) {
+        this._referenceCache = {};
+      }
+
       // if we're creating an item, this process will be done
       // later, once the object has been persisted.
       if (!Ember.isEmpty(reference.id)) {
@@ -1391,36 +1566,33 @@
       }
     }
   });
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   var supportsComputedGetterSetter;
-  
+
   try {
     Ember.computed({
-      get: function() { },
-      set: function() { }
+      get: function() {},
+      set: function() {}
     });
     supportsComputedGetterSetter = true;
-  } catch(e) {
+  } catch (e) {
     supportsComputedGetterSetter = false;
   }
-  
+
   Ember.Model.computed = function() {
     var polyfillArguments = [];
     var config = arguments[arguments.length - 1];
-  
-    if (typeof config === 'function' || supportsComputedGetterSetter) {
+
+    if (typeof config === "function" || supportsComputedGetterSetter) {
       return Ember.computed.apply(null, arguments);
     }
-  
+
     for (var i = 0, l = arguments.length - 1; i < l; i++) {
       polyfillArguments.push(arguments[i]);
     }
-  
+
     var func;
     if (config.set) {
       func = function(key, value, oldValue) {
@@ -1435,62 +1607,73 @@
         return config.get.call(this, key);
       };
     }
-  
+
     polyfillArguments.push(func);
-  
+
     return Ember.computed.apply(null, polyfillArguments);
   };
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   var get = Ember.get;
-  
+
   function getType(record) {
     var type = this.type;
-  
+
     if (typeof this.type === "string" && this.type) {
       this.type = get(Ember.lookup, this.type);
-  
+
       if (!this.type) {
-        var emstore = Ember.getOwner(record).lookup('emstore:main');
+        var emstore = Ember.getOwner(record).lookup("emstore:main");
         this.type = emstore.modelFor(type);
         this.type.reopenClass({ adapter: emstore.adapterFor(type) });
       }
     }
-  
+
     return this.type;
   }
-  
+
   Ember.hasMany = function(type, options) {
     options = options || {};
-  
-    var meta = { type: type, isRelationship: true, options: options, kind: 'hasMany', getType: getType};
-  
+
+    var meta = {
+      type: type,
+      isRelationship: true,
+      options: options,
+      kind: "hasMany",
+      getType: getType
+    };
+
     return Ember.Model.computed({
       get: function(propertyKey) {
         type = meta.getType(this);
         Ember.assert("Type cannot be empty", !Ember.isEmpty(type));
-  
+
         var key = options.key || propertyKey;
         var owner = Ember.getOwner(this);
         return this.getHasMany(key, type, meta, owner);
       },
       set: function(propertyKey, newContentArray, existingArray) {
         if (!existingArray) {
-          existingArray = this.getHasMany(options.key || propertyKey, type, meta, Ember.getOwner(this));
+          existingArray = this.getHasMany(
+            options.key || propertyKey,
+            type,
+            meta,
+            Ember.getOwner(this)
+          );
         }
         return existingArray.setObjects(newContentArray);
       }
     }).meta(meta);
   };
-  
+
   Ember.Model.reopen({
     getHasMany: function(key, type, meta, owner) {
       var embedded = meta.options.embedded,
-          collectionClass = embedded ? Ember.EmbeddedHasManyArray : Ember.HasManyArray;
-  
+        collectionClass = embedded
+          ? Ember.EmbeddedHasManyArray
+          : Ember.HasManyArray;
+
       var collection = collectionClass.create({
         parent: this,
         modelClass: type,
@@ -1499,145 +1682,154 @@
         key: key,
         relationshipKey: meta.relationshipKey
       });
-  
+
       Ember.setOwner(collection, owner);
       this._registerHasManyArray(collection);
-  
+
       return collection;
     }
   });
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   var get = Ember.get,
-      set = Ember.set;
-  
+    set = Ember.set;
+
   function storeFor(record) {
     var owner = Ember.getOwner(record);
-  
+
     if (owner) {
-      return owner.lookup('emstore:main');
+      return owner.lookup("emstore:main");
     }
-  
+
     return null;
   }
-  
+
   function getType(record) {
     var type = this.type;
-  
+
     if (typeof this.type === "string" && this.type) {
       type = Ember.get(Ember.lookup, this.type);
-  
+
       if (!type) {
         var emstore = storeFor(record);
         type = emstore.modelFor(this.type);
         type.reopenClass({ adapter: emstore.adapterFor(this.type) });
       }
     }
-  
+
     return type;
   }
-  
+
   Ember.belongsTo = function(type, options) {
     options = options || {};
-  
-    var meta = { type: type, isRelationship: true, options: options, kind: 'belongsTo', getType: getType};
-  
+
+    var meta = {
+      type: type,
+      isRelationship: true,
+      options: options,
+      kind: "belongsTo",
+      getType: getType
+    };
+
     return Ember.Model.computed("_data", {
-      get: function(propertyKey){
+      get: function(propertyKey) {
         type = meta.getType(this);
         Ember.assert("Type cannot be empty.", !Ember.isEmpty(type));
-  
+
         var key = options.key || propertyKey,
-            self = this;
-  
+          self = this;
+
         var dirtyChanged = function(sender) {
-          if (sender.get('isDirty')) {
+          if (sender.get("isDirty")) {
             self._relationshipBecameDirty(propertyKey);
           } else {
             self._relationshipBecameClean(propertyKey);
           }
         };
-  
+
         var emstore = storeFor(this),
-            value = this.getBelongsTo(key, type, meta, emstore);
+          value = this.getBelongsTo(key, type, meta, emstore);
         this._registerBelongsTo(meta);
         if (value !== null && meta.options.embedded) {
-          value.get('isDirty'); // getter must be called before adding observer
-          value.addObserver('isDirty', dirtyChanged);
+          value.get("isDirty"); // getter must be called before adding observer
+          value.addObserver("isDirty", dirtyChanged);
         }
         return value;
       },
-  
-      set: function(propertyKey, value, oldValue){
+
+      set: function(propertyKey, value, oldValue) {
         type = meta.getType(this);
         Ember.assert("Type cannot be empty.", !Ember.isEmpty(type));
-  
-        var dirtyAttributes = get(this, '_dirtyAttributes'),
-            createdDirtyAttributes = false,
-            self = this;
-  
+
+        var dirtyAttributes = get(this, "_dirtyAttributes"),
+          createdDirtyAttributes = false,
+          self = this;
+
         var dirtyChanged = function(sender) {
-          if (sender.get('isDirty')) {
+          if (sender.get("isDirty")) {
             self._relationshipBecameDirty(propertyKey);
           } else {
             self._relationshipBecameClean(propertyKey);
           }
         };
-  
+
         if (!dirtyAttributes) {
           dirtyAttributes = [];
           createdDirtyAttributes = true;
         }
-  
+
         if (value) {
-          Ember.assert('Attempted to set property of type: ' + value.constructor + ' with a value of type: ' + type, value instanceof type);
+          Ember.assert(
+            "Attempted to set property of type: " +
+              value.constructor +
+              " with a value of type: " +
+              type,
+            value instanceof type
+          );
         }
-  
+
         if (oldValue !== value) {
           dirtyAttributes.pushObject(propertyKey);
         } else {
           dirtyAttributes.removeObject(propertyKey);
         }
-  
+
         if (createdDirtyAttributes) {
-          set(this, '_dirtyAttributes', dirtyAttributes);
+          set(this, "_dirtyAttributes", dirtyAttributes);
         }
-  
+
         if (meta.options.embedded) {
           if (oldValue) {
-            oldValue.removeObserver('isDirty', dirtyChanged);
+            oldValue.removeObserver("isDirty", dirtyChanged);
           }
           if (value) {
-            value.addObserver('isDirty', dirtyChanged);
+            value.addObserver("isDirty", dirtyChanged);
           }
         }
-  
+
         return value === undefined ? null : value;
       }
     }).meta(meta);
   };
-  
+
   Ember.Model.reopen({
     getBelongsTo: function(key, type, meta, emstore) {
-      var idOrAttrs = get(this, '_data.' + key),
-          record;
-  
+      var idOrAttrs = get(this, "_data." + key),
+        record;
+
       if (Ember.isNone(idOrAttrs)) {
         return null;
       }
-  
+
       if (meta.options.embedded) {
-        var primaryKey = get(type, 'primaryKey'),
+        var primaryKey = get(type, "primaryKey"),
           id = idOrAttrs[primaryKey];
         record = type.create({ isLoaded: false, id: id });
-  
+
         var owner = Ember.getOwner(this);
         Ember.setOwner(record, owner);
-  
+
         record.load(id, idOrAttrs);
       } else {
         if (emstore) {
@@ -1646,49 +1838,58 @@
           record = type.find(idOrAttrs);
         }
       }
-  
+
       return record;
     }
   });
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   var get = Ember.get,
-      set = Ember.set,
-      meta = Ember.meta;
-  
+    set = Ember.set,
+    meta = Ember.meta;
+
   Ember.Model.dataTypes = {};
-  
+
   Ember.Model.dataTypes[Date] = {
     deserialize: function(string) {
-      if (!string) { return null; }
+      if (!string) {
+        return null;
+      }
       return new Date(string);
     },
-    serialize: function (date) {
-      if (!date) { return null; }
+    serialize: function(date) {
+      if (!date) {
+        return null;
+      }
       return date.toISOString();
     },
     isEqual: function(obj1, obj2) {
-      if (obj1 instanceof Date) { obj1 = this.serialize(obj1); }
-      if (obj2 instanceof Date) { obj2 = this.serialize(obj2); }
+      if (obj1 instanceof Date) {
+        obj1 = this.serialize(obj1);
+      }
+      if (obj2 instanceof Date) {
+        obj2 = this.serialize(obj2);
+      }
       return obj1 === obj2;
     }
   };
-  
+
   Ember.Model.dataTypes[Number] = {
     deserialize: function(string) {
-      if (!string && string !== 0) { return null; }
+      if (!string && string !== 0) {
+        return null;
+      }
       return Number(string);
     },
-    serialize: function (number) {
-      if (!number && number !== 0) { return null; }
+    serialize: function(number) {
+      if (!number && number !== 0) {
+        return null;
+      }
       return Number(number);
     }
   };
-  
+
   function deserialize(value, type) {
     if (type && type.deserialize) {
       return type.deserialize(value);
@@ -1698,7 +1899,7 @@
       return value;
     }
   }
-  
+
   function serialize(value, type) {
     if (type && type.serialize) {
       return type.serialize(value);
@@ -1708,166 +1909,168 @@
       return value;
     }
   }
-  
+
   Ember.attr = function(type, options) {
     return Ember.Model.computed("_data", {
-      get: function(key){
-        var data = get(this, '_data'),
-            dataKey = this.dataKey(key),
-            dataValue = data && get(data, dataKey);
-  
-        if (dataValue==null && options && options.defaultValue!=null) {
+      get: function(key) {
+        var data = get(this, "_data"),
+          dataKey = this.dataKey(key),
+          dataValue = data && get(data, dataKey);
+
+        if (dataValue == null && options && options.defaultValue != null) {
           return Ember.copy(options.defaultValue);
         }
-  
+
         return this.getAttr(key, deserialize(dataValue, type));
       },
-      set: function(key, value){
-        var data = get(this, '_data'),
-            dataKey = this.dataKey(key),
-            dataValue = data && get(data, dataKey),
-            dirtyAttributes = get(this, '_dirtyAttributes'),
-            createdDirtyAttributes = false;
+      set: function(key, value) {
+        var data = get(this, "_data"),
+          dataKey = this.dataKey(key),
+          dataValue = data && get(data, dataKey),
+          dirtyAttributes = get(this, "_dirtyAttributes"),
+          createdDirtyAttributes = false;
         if (!dirtyAttributes) {
           dirtyAttributes = Ember.A([]);
           createdDirtyAttributes = true;
         }
-  
+
         if (dataValue !== serialize(value, type)) {
           dirtyAttributes.pushObject(key);
         } else {
           dirtyAttributes.removeObject(key);
         }
-  
+
         if (createdDirtyAttributes) {
-          set(this, '_dirtyAttributes', dirtyAttributes);
+          set(this, "_dirtyAttributes", dirtyAttributes);
         }
-  
+
         return value;
       }
-    }).meta({isAttribute: true, type: type, options: options});
+    }).meta({ isAttribute: true, type: type, options: options });
   };
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   var get = Ember.get;
-  
+
   Ember.RESTAdapter = Ember.Adapter.extend({
     find: function(record, id) {
       var url = this.buildURL(record.constructor, id),
-          self = this;
-  
+        self = this;
+
       return this.ajax(url).then(function(data) {
         self.didFind(record, id, data);
         return record;
       });
     },
-  
+
     didFind: function(record, id, data) {
-      var rootKey = get(record.constructor, 'rootKey'),
-          dataToLoad = rootKey ? get(data, rootKey) : data;
-  
+      var rootKey = get(record.constructor, "rootKey"),
+        dataToLoad = rootKey ? get(data, rootKey) : data;
+
       record.load(id, dataToLoad);
     },
-  
+
     findAll: function(klass, records) {
       var url = this.buildURL(klass),
-          self = this;
-  
+        self = this;
+
       return this.ajax(url).then(function(data) {
         self.didFindAll(klass, records, data);
         return records;
       });
     },
-  
+
     didFindAll: function(klass, records, data) {
-      var collectionKey = get(klass, 'collectionKey'),
-          dataToLoad = collectionKey ? get(data, collectionKey) : data;
-  
+      var collectionKey = get(klass, "collectionKey"),
+        dataToLoad = collectionKey ? get(data, collectionKey) : data;
+
       records.load(klass, dataToLoad);
     },
-  
+
     findQuery: function(klass, records, params) {
       var url = this.buildURL(klass),
-          self = this;
-  
+        self = this;
+
       return this.ajax(url, params).then(function(data) {
         self.didFindQuery(klass, records, params, data);
         return records;
       });
     },
-  
+
     didFindQuery: function(klass, records, params, data) {
-        var collectionKey = get(klass, 'collectionKey'),
-            dataToLoad = collectionKey ? get(data, collectionKey) : data;
-  
-        records.load(klass, dataToLoad);
+      var collectionKey = get(klass, "collectionKey"),
+        dataToLoad = collectionKey ? get(data, collectionKey) : data;
+
+      records.load(klass, dataToLoad);
     },
-  
+
     createRecord: function(record) {
       var url = this.buildURL(record.constructor),
-          self = this;
-  
+        self = this;
+
       return this.ajax(url, record.toJSON(), "POST").then(function(data) {
         self.didCreateRecord(record, data);
         return record;
       });
     },
-  
+
     didCreateRecord: function(record, data) {
       this._loadRecordFromData(record, data);
       record.didCreateRecord();
     },
-  
+
     saveRecord: function(record) {
-      var primaryKey = get(record.constructor, 'primaryKey'),
-          url = this.buildURL(record.constructor, get(record, primaryKey)),
-          self = this;
-  
-      return this.ajax(url, record.toJSON(), "PUT").then(function(data) {  // TODO: Some APIs may or may not return data
+      var primaryKey = get(record.constructor, "primaryKey"),
+        url = this.buildURL(record.constructor, get(record, primaryKey)),
+        self = this;
+
+      return this.ajax(url, record.toJSON(), "PUT").then(function(data) {
+        // TODO: Some APIs may or may not return data
         self.didSaveRecord(record, data);
         return record;
       });
     },
-  
+
     didSaveRecord: function(record, data) {
       this._loadRecordFromData(record, data);
       record.didSaveRecord();
     },
-  
+
     deleteRecord: function(record) {
-      var primaryKey = get(record.constructor, 'primaryKey'),
-          url = this.buildURL(record.constructor, get(record, primaryKey)),
-          self = this;
-  
+      var primaryKey = get(record.constructor, "primaryKey"),
+        url = this.buildURL(record.constructor, get(record, primaryKey)),
+        self = this;
+
       return this.ajax(url, record.toJSON(), "DELETE").then(function(data) {
         self.didDeleteRecord(record, data);
       });
     },
-  
+
     didDeleteRecord: function(record, data) {
       record.didDeleteRecord();
     },
-  
+
     ajax: function(url, params, method, settings) {
-      return this._ajax(url, params, (method || "GET"), settings);
+      return this._ajax(url, params, method || "GET", settings);
     },
-  
+
     buildURL: function(klass, id) {
-      var urlRoot = get(klass, 'url');
-      var urlSuffix = get(klass, 'urlSuffix') || '';
-      if (!urlRoot) { throw new Error('Ember.RESTAdapter requires a `url` property to be specified'); }
-  
+      var urlRoot = get(klass, "url");
+      var urlSuffix = get(klass, "urlSuffix") || "";
+      if (!urlRoot) {
+        throw new Error(
+          "Ember.RESTAdapter requires a `url` property to be specified"
+        );
+      }
+
       if (!Ember.isEmpty(id)) {
         return urlRoot + "/" + id + urlSuffix;
       } else {
         return urlRoot + urlSuffix;
       }
     },
-  
+
     ajaxSettings: function(url, method) {
       return {
         url: url,
@@ -1875,13 +2078,13 @@
         dataType: "json"
       };
     },
-  
+
     _ajax: function(url, params, method, settings) {
       var self = this;
       if (!settings) {
         settings = this.ajaxSettings(url, method);
       }
-  
+
       return new Ember.RSVP.Promise(function(resolve, reject) {
         if (params) {
           if (method === "GET") {
@@ -1891,25 +2094,24 @@
             settings.data = JSON.stringify(params);
           }
         }
-  
+
         settings.success = function(json) {
           Ember.run(null, resolve, json);
         };
-  
+
         settings.error = function(jqXHR, textStatus, errorThrown) {
           // https://github.com/ebryn/ember-model/issues/202
-          if (jqXHR && typeof jqXHR === 'object') {
+          if (jqXHR && typeof jqXHR === "object") {
             jqXHR.then = null;
           }
-  
+
           self._handleRejections(method, jqXHR, resolve, reject);
         };
-  
-  
+
         Ember.$.ajax(settings);
-     }, "ember-model: RESTAdapter#ajax ${method} to " + url);
+      }, "ember-model: RESTAdapter#ajax ${method} to " + url);
     },
-  
+
     _handleRejections: function(method, jqXHR, resolve, reject) {
       if (method === "DELETE" && jqXHR.status >= 200 && jqXHR.status < 300) {
         Ember.run(null, resolve, null);
@@ -1917,10 +2119,10 @@
         Ember.run(null, reject, jqXHR);
       }
     },
-  
+
     _loadRecordFromData: function(record, data) {
-      var rootKey = get(record.constructor, 'rootKey'),
-          primaryKey = get(record.constructor, 'primaryKey');
+      var rootKey = get(record.constructor, "rootKey"),
+        primaryKey = get(record.constructor, "primaryKey");
       // handle HEAD response where no data is provided by server
       if (data) {
         data = rootKey ? get(data, rootKey) : data;
@@ -1930,14 +2132,11 @@
       }
     }
   });
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   var get = Ember.get;
-  
+
   Ember.loadPromise = function(target) {
     if (Ember.isNone(target)) {
       return null;
@@ -1945,64 +2144,72 @@
       return target;
     } else {
       var deferred = Ember.RSVP.defer();
-  
-      if (get(target, 'isLoaded') && !get(target, 'isNew')) {
+
+      if (get(target, "isLoaded") && !get(target, "isNew")) {
         deferred.resolve(target);
       } else {
-        target.one('didLoad', this, function() {
+        target.one("didLoad", this, function() {
           deferred.resolve(target);
         });
       }
-  
+
       return deferred.promise;
     }
   };
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   // This is a debug adapter for the Ember Extension, don't let the fact this is called an "adapter" confuse you.
   // Most copied from: https://github.com/emberjs/data/blob/master/packages/ember-data/lib/system/debug/debug_adapter.js
-  
-  if (!Ember.DataAdapter) { return; }
-  
-  var get = Ember.get, capitalize = Ember.String.capitalize, underscore = Ember.String.underscore;
-  
+
+  if (!Ember.DataAdapter) {
+    return;
+  }
+
+  var get = Ember.get,
+    capitalize = Ember.String.capitalize,
+    underscore = Ember.String.underscore;
+
   var DebugAdapter = Ember.DataAdapter.extend({
     getFilters: function() {
       return [
-        { name: 'isNew', desc: 'New' },
-        { name: 'isModified', desc: 'Modified' },
-        { name: 'isClean', desc: 'Clean' }
+        { name: "isNew", desc: "New" },
+        { name: "isModified", desc: "Modified" },
+        { name: "isClean", desc: "Clean" }
       ];
     },
-  
+
     detect: function(klass) {
       return klass !== Ember.Model && Ember.Model.detect(klass);
     },
-  
+
     columnsForType: function(type) {
-      var columns = [], count = 0, self = this;
+      var columns = [],
+        count = 0,
+        self = this;
       type.getAttributes().forEach(function(name, meta) {
-          if (count++ > self.attributeLimit) { return false; }
-          var desc = capitalize(underscore(name).replace('_', ' '));
-          columns.push({ name: name, desc: desc });
+        if (count++ > self.attributeLimit) {
+          return false;
+        }
+        var desc = capitalize(underscore(name).replace("_", " "));
+        columns.push({ name: name, desc: desc });
       });
       return columns;
     },
-  
+
     getRecords: function(type) {
       var records = [];
-      type.forEachCachedRecord(function(record) { records.push(record); });
+      type.forEachCachedRecord(function(record) {
+        records.push(record);
+      });
       return records;
     },
-  
+
     getRecordColumnValues: function(record) {
-      var self = this, count = 0,
-          columnValues = { id: get(record, 'id') };
-  
+      var self = this,
+        count = 0,
+        columnValues = { id: get(record, "id") };
+
       record.constructor.getAttributes().forEach(function(key) {
         if (count++ > self.attributeLimit) {
           return false;
@@ -2012,9 +2219,10 @@
       });
       return columnValues;
     },
-  
+
     getRecordKeywords: function(record) {
-      var keywords = [], keys = Ember.A(['id']);
+      var keywords = [],
+        keys = Ember.A(["id"]);
       record.constructor.getAttributes().forEach(function(key) {
         keys.push(key);
       });
@@ -2023,33 +2231,34 @@
       });
       return keywords;
     },
-  
+
     getRecordFilterValues: function(record) {
       return {
-        isNew: record.get('isNew'),
-        isModified: record.get('isDirty') && !record.get('isNew'),
-        isClean: !record.get('isDirty')
+        isNew: record.get("isNew"),
+        isModified: record.get("isDirty") && !record.get("isNew"),
+        isClean: !record.get("isDirty")
       };
     },
-  
+
     getRecordColor: function(record) {
-      var color = 'black';
-      if (record.get('isNew')) {
-        color = 'green';
-      } else if (record.get('isDirty')) {
-        color = 'blue';
+      var color = "black";
+      if (record.get("isNew")) {
+        color = "green";
+      } else if (record.get("isDirty")) {
+        color = "blue";
       }
       return color;
     },
-  
+
     observeRecord: function(record, recordUpdated) {
-      var releaseMethods = Ember.A(), self = this,
-          keysToObserve = Ember.A(['id', 'isNew', 'isDirty']);
-  
+      var releaseMethods = Ember.A(),
+        self = this,
+        keysToObserve = Ember.A(["id", "isNew", "isDirty"]);
+
       record.constructor.getAttributes().forEach(function(key) {
         keysToObserve.push(key);
       });
-  
+
       keysToObserve.forEach(function(key) {
         var handler = function() {
           recordUpdated(self.wrapRecord(record));
@@ -2059,112 +2268,110 @@
           Ember.removeObserver(record, key, handler);
         });
       });
-  
+
       var release = function() {
-        releaseMethods.forEach(function(fn) { fn(); } );
+        releaseMethods.forEach(function(fn) {
+          fn();
+        });
       };
-  
+
       return release;
     }
   });
-  
-  Ember.onLoad('Ember.Application', function(Application) {
+
+  Ember.onLoad("Ember.Application", function(Application) {
     Application.initializer({
       name: "em-data-adapter",
-  
+
       initialize: function() {
         var application = arguments[1] || arguments[0];
-        application.register('em-data-adapter:main', DebugAdapter);
+        application.register("em-data-adapter:main", DebugAdapter);
       }
     });
   });
-  
-  
-  })();
-  
-  (function() {
-  
+})();
+
+(function() {
   function NIL() {}
-  
+
   Ember.Model.Store = Ember.Service.extend({
     modelFor: function(type) {
-      return Ember.getOwner(this).factoryFor('model:' + type).class;
+      return Ember.getOwner(this).factoryFor("model:" + type).class;
     },
-  
+
     adapterFor: function(type) {
       var adapter = this.modelFor(type).adapter;
       var owner = Ember.getOwner(this);
-  
+
       if (adapter && adapter !== Ember.Model.adapter) {
         return adapter;
       } else {
-        adapter = owner.factoryFor('adapter:' + type) ||
-          owner.factoryFor('adapter:application') ||
-          owner.factoryFor('adapter:REST');
-  
+        adapter =
+          owner.factoryFor("adapter:" + type) ||
+          owner.factoryFor("adapter:application") ||
+          owner.factoryFor("adapter:REST");
+
         return adapter ? adapter.create() : adapter;
       }
     },
-  
+
     createRecord: function(type, props) {
       var klass = this.modelFor(type);
-      klass.reopenClass({adapter: this.adapterFor(type)});
-  
+      klass.reopenClass({ adapter: this.adapterFor(type) });
+
       var record = klass.create(props);
-  
+
       var owner = Ember.getOwner(this);
       Ember.setOwner(record, owner);
-  
+
       return record;
     },
-  
+
     find: function(type, id) {
-      if (arguments.length === 1) { id = NIL; }
+      if (arguments.length === 1) {
+        id = NIL;
+      }
       return this._find(type, id, true);
     },
-  
+
     _find: function(type, id, isAsync) {
       var klass = this.modelFor(type);
-  
+
       // if (!klass.adapter) {
-        klass.reopenClass({adapter: this.adapterFor(type)});
+      klass.reopenClass({ adapter: this.adapterFor(type) });
       // }
-  
+
       var owner = Ember.getOwner(this);
-  
+
       if (id === NIL) {
         return klass._findFetchAll(isAsync, owner);
       } else if (Ember.isArray(id)) {
         return klass._findFetchMany(id, isAsync, owner);
-      } else if (typeof id === 'object') {
+      } else if (typeof id === "object") {
         return klass._findFetchQuery(id, isAsync, owner);
       } else {
         return klass._findFetchById(id, isAsync, owner);
       }
     },
-  
+
     _findSync: function(type, id) {
       return this._find(type, id, false);
     }
   });
-  
-  Ember.onLoad('Ember.Application', function(Application) {
-  
+
+  Ember.onLoad("Ember.Application", function(Application) {
     Application.initializer({
       name: "emstore",
-  
+
       initialize: function() {
         var application = arguments[1] || arguments[0];
         var store = application.Store || Ember.Model.Store;
-        application.register('emstore:application', store);
-        application.register('emstore:main', store);
-  
-        application.inject('route', 'emstore', 'emstore:main');
-        application.inject('controller', 'emstore', 'emstore:main');
+        application.register("emstore:application", store);
+        application.register("emstore:main", store);
+
+        application.inject("route", "emstore", "emstore:main");
+        application.inject("controller", "emstore", "emstore:main");
       }
     });
-  
   });
-  
-  
-  })();
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,29 +10,29 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "7.0.0"
       }
     },
     "@babel/core": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
-      "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.4.tgz",
+      "integrity": "sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.0",
-        "@babel/helpers": "^7.4.3",
-        "@babel/parser": "^7.4.3",
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0",
-        "convert-source-map": "^1.1.0",
-        "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.11",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.4.4",
+        "@babel/helpers": "7.4.4",
+        "@babel/parser": "7.4.4",
+        "@babel/template": "7.4.4",
+        "@babel/traverse": "7.4.4",
+        "@babel/types": "7.4.4",
+        "convert-source-map": "1.6.0",
+        "debug": "4.1.1",
+        "json5": "2.1.0",
+        "lodash": "4.17.11",
+        "resolve": "1.10.1",
+        "semver": "5.5.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -41,7 +41,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "lodash": {
@@ -63,12 +63,12 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "path-parse": "1.0.6"
           }
         },
         "source-map": {
@@ -80,16 +80,16 @@
       }
     },
     "@babel/generator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-      "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.4.4",
+        "jsesc": "2.5.2",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "lodash": {
@@ -112,7 +112,7 @@
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -121,44 +121,44 @@
       "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-explode-assignable-expression": "7.1.0",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
-      "integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+      "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.0",
-        "@babel/traverse": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/helper-hoist-variables": "7.4.4",
+        "@babel/traverse": "7.4.4",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.3.tgz",
-      "integrity": "sha512-UMl3TSpX11PuODYdWGrUeW6zFkdYhDn7wRLrOuNVM6f9L+S9CzmDXYyrp3MTHcwWjnzur1f/Op8A7iYZWya2Yg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.4.tgz",
+      "integrity": "sha512-UbBHIa2qeAGgyiNR9RszVF7bUHEdgS4JAUNT8SiqrAN6YJVxlOxeLr5pBzb5kan302dejJ9nla4RyKcR1XT6XA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.4.0",
-        "@babel/helper-split-export-declaration": "^7.4.0"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-member-expression-to-functions": "7.0.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.4.4",
+        "@babel/helper-split-export-declaration": "7.4.4"
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
-      "integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
+      "integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.4.0",
-        "lodash": "^4.17.11"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/types": "7.4.4",
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "lodash": {
@@ -175,8 +175,8 @@
       "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/traverse": "7.4.4",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-function-name": {
@@ -185,9 +185,9 @@
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/template": "7.4.4",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -196,16 +196,16 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
-      "integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+      "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0"
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -214,7 +214,7 @@
       "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-module-imports": {
@@ -223,21 +223,21 @@
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
-      "integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+      "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/template": "^7.2.2",
-        "@babel/types": "^7.2.2",
-        "lodash": "^4.17.11"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.4.4",
+        "@babel/template": "7.4.4",
+        "@babel/types": "7.4.4",
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "lodash": {
@@ -254,7 +254,7 @@
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -264,12 +264,12 @@
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
-      "integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+      "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "lodash": {
@@ -286,23 +286,23 @@
       "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-wrap-function": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-wrap-function": "7.2.0",
+        "@babel/template": "7.4.4",
+        "@babel/traverse": "7.4.4",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
-      "integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
+      "integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/helper-member-expression-to-functions": "7.0.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/traverse": "7.4.4",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-simple-access": {
@@ -311,17 +311,17 @@
       "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/template": "7.4.4",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
-      "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0"
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helper-wrap-function": {
@@ -330,21 +330,21 @@
       "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.2.0"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/template": "7.4.4",
+        "@babel/traverse": "7.4.4",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/helpers": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
-      "integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+      "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0"
+        "@babel/template": "7.4.4",
+        "@babel/traverse": "7.4.4",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/highlight": {
@@ -353,9 +353,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.2",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -364,7 +364,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "chalk": {
@@ -373,9 +373,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "supports-color": {
@@ -384,15 +384,15 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
     "@babel/parser": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+      "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -401,30 +401,30 @@
       "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0",
-        "@babel/plugin-syntax-async-generators": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0",
+        "@babel/plugin-syntax-async-generators": "7.2.0"
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz",
-      "integrity": "sha512-t2ECPNOXsIeK1JxJNKmgbzQtoG27KIlVE61vTqX0DKR9E9sZlVVxWUtEW9D5FlZ8b8j7SBNCHY47GgPKCKlpPg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.4.tgz",
+      "integrity": "sha512-WjKTI8g8d5w1Bc9zgwSz2nfrsNQsXcCf9J9cdCvrJV6RF56yztwm4TmJC0MgJ9tvwO9gUA/mcYe89bLdGfiXFg==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.4.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-create-class-features-plugin": "7.4.4",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-proposal-decorators": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.0.tgz",
-      "integrity": "sha512-d08TLmXeK/XbgCo7ZeZ+JaeZDtDai/2ctapTRsWWkkmy7G/cqz8DQN/HlWG7RR4YmfXxmExsbU3SuCjlM7AtUg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.4.tgz",
+      "integrity": "sha512-z7MpQz3XC/iQJWXH9y+MaWcLPNSMY9RQSthrLzak8R8hCj0fuyNk+Dzi9kfNe/JxxlWQ2g7wkABbgWjW36MTcw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.4.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-decorators": "^7.2.0"
+        "@babel/helper-create-class-features-plugin": "7.4.4",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-decorators": "7.2.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -433,18 +433,18 @@
       "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-json-strings": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-json-strings": "7.2.0"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
-      "integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
+      "integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -453,19 +453,19 @@
       "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.2.0"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
-      "integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+      "integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.5.4"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.4.4",
+        "regexpu-core": "4.5.4"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -474,7 +474,7 @@
       "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-decorators": {
@@ -483,7 +483,7 @@
       "integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -492,7 +492,7 @@
       "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -501,7 +501,7 @@
       "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
@@ -510,7 +510,7 @@
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -519,18 +519,18 @@
       "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
-      "integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
+      "integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -539,17 +539,17 @@
       "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
-      "integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
+      "integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.11"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "lodash": {
@@ -561,19 +561,19 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
-      "integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
+      "integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.4.0",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.4.0",
-        "@babel/helper-split-export-declaration": "^7.4.0",
-        "globals": "^11.1.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-define-map": "7.4.4",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.4.4",
+        "@babel/helper-split-export-declaration": "7.4.4",
+        "globals": "11.12.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -582,27 +582,27 @@
       "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
-      "integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
+      "integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
-      "integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+      "integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.3",
-        "regexpu-core": "^4.5.4"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.4.4",
+        "regexpu-core": "4.5.4"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -611,7 +611,7 @@
       "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -620,27 +620,27 @@
       "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
-      "integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+      "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
-      "integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+      "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-literals": {
@@ -649,7 +649,7 @@
       "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-member-expression-literals": {
@@ -658,7 +658,7 @@
       "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-amd": {
@@ -667,29 +667,29 @@
       "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-module-transforms": "7.4.4",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
-      "integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
+      "integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.4.3",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0"
+        "@babel/helper-module-transforms": "7.4.4",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
-      "integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
+      "integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-hoist-variables": "7.4.4",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -698,26 +698,26 @@
       "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-module-transforms": "7.4.4",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.2.tgz",
-      "integrity": "sha512-NsAuliSwkL3WO2dzWTOL1oZJHm0TM8ZY8ZSxk2ANyKkt5SQlToGA4pzctmq1BEjoacurdwZ3xp2dCQWJkME0gQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.4.tgz",
+      "integrity": "sha512-Ki+Y9nXBlKfhD+LXaRS7v95TtTGYRAf9Y1rTDiE75zf8YQz4GDaWRXosMfJBXxnk88mGFjWdCRIeqDbon7spYA==",
       "dev": true,
       "requires": {
-        "regexp-tree": "^0.1.0"
+        "regexp-tree": "0.1.6"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
-      "integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+      "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-object-super": {
@@ -726,19 +726,19 @@
       "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.4.4"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
-      "integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+      "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "^7.4.0",
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-call-delegate": "7.4.4",
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-property-literals": {
@@ -747,16 +747,16 @@
       "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
-      "integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.4.tgz",
+      "integrity": "sha512-Zz3w+pX1SI0KMIiqshFZkwnVGUhDZzpX2vtPzfJBKQQq8WsP/Xy9DNdELWivxcKOCX/Pywge4SiEaPaLtoDT4g==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.13.4"
+        "regenerator-transform": "0.13.4"
       }
     },
     "@babel/plugin-transform-reserved-words": {
@@ -765,19 +765,19 @@
       "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz",
-      "integrity": "sha512-7Q61bU+uEI7bCUFReT1NKn7/X6sDQsZ7wL1sJ9IYMAO7cI+eg6x9re1cEw2fCRMbbTVyoeUKWSV1M6azEfKCfg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz",
+      "integrity": "sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.1"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "resolve": "1.10.1",
+        "semver": "5.7.0"
       },
       "dependencies": {
         "path-parse": {
@@ -787,12 +787,12 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "path-parse": "1.0.6"
           }
         },
         "semver": {
@@ -809,7 +809,7 @@
       "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-spread": {
@@ -818,7 +818,7 @@
       "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -827,18 +827,18 @@
       "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.4.4"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
-      "integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+      "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
@@ -847,121 +847,121 @@
       "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
-      "integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+      "integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.4.3",
-        "regexpu-core": "^4.5.4"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.4.4",
+        "regexpu-core": "4.5.4"
       }
     },
     "@babel/polyfill": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.3.tgz",
-      "integrity": "sha512-rkv8WIvJshA5Ev8iNMGgz5WZkRtgtiPexiT7w5qevGTuT7ZBfM3de9ox1y9JR5/OXb/sWGBbWlHNa7vQKqku3Q==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
       "dev": true,
       "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
+        "core-js": "2.6.5",
+        "regenerator-runtime": "0.13.2"
       }
     },
     "@babel/preset-env": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
-      "integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.4.tgz",
+      "integrity": "sha512-FU1H+ACWqZZqfw1x2G1tgtSSYSfxJLkpaUQL37CenULFARDo+h4xJoVHzRoHbK+85ViLciuI7ME4WTIhFRBBlw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-        "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
-        "@babel/plugin-syntax-async-generators": "^7.2.0",
-        "@babel/plugin-syntax-json-strings": "^7.2.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.4.0",
-        "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.4.0",
-        "@babel/plugin-transform-classes": "^7.4.3",
-        "@babel/plugin-transform-computed-properties": "^7.2.0",
-        "@babel/plugin-transform-destructuring": "^7.4.3",
-        "@babel/plugin-transform-dotall-regex": "^7.4.3",
-        "@babel/plugin-transform-duplicate-keys": "^7.2.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-        "@babel/plugin-transform-for-of": "^7.4.3",
-        "@babel/plugin-transform-function-name": "^7.4.3",
-        "@babel/plugin-transform-literals": "^7.2.0",
-        "@babel/plugin-transform-member-expression-literals": "^7.2.0",
-        "@babel/plugin-transform-modules-amd": "^7.2.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.4.3",
-        "@babel/plugin-transform-modules-systemjs": "^7.4.0",
-        "@babel/plugin-transform-modules-umd": "^7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
-        "@babel/plugin-transform-new-target": "^7.4.0",
-        "@babel/plugin-transform-object-super": "^7.2.0",
-        "@babel/plugin-transform-parameters": "^7.4.3",
-        "@babel/plugin-transform-property-literals": "^7.2.0",
-        "@babel/plugin-transform-regenerator": "^7.4.3",
-        "@babel/plugin-transform-reserved-words": "^7.2.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.2.0",
-        "@babel/plugin-transform-spread": "^7.2.0",
-        "@babel/plugin-transform-sticky-regex": "^7.2.0",
-        "@babel/plugin-transform-template-literals": "^7.2.0",
-        "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-        "@babel/plugin-transform-unicode-regex": "^7.4.3",
-        "@babel/types": "^7.4.0",
-        "browserslist": "^4.5.2",
-        "core-js-compat": "^3.0.0",
-        "invariant": "^2.2.2",
-        "js-levenshtein": "^1.1.3",
-        "semver": "^5.5.0"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "7.2.0",
+        "@babel/plugin-proposal-json-strings": "7.2.0",
+        "@babel/plugin-proposal-object-rest-spread": "7.4.4",
+        "@babel/plugin-proposal-optional-catch-binding": "7.2.0",
+        "@babel/plugin-proposal-unicode-property-regex": "7.4.4",
+        "@babel/plugin-syntax-async-generators": "7.2.0",
+        "@babel/plugin-syntax-json-strings": "7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.2.0",
+        "@babel/plugin-transform-arrow-functions": "7.2.0",
+        "@babel/plugin-transform-async-to-generator": "7.4.4",
+        "@babel/plugin-transform-block-scoped-functions": "7.2.0",
+        "@babel/plugin-transform-block-scoping": "7.4.4",
+        "@babel/plugin-transform-classes": "7.4.4",
+        "@babel/plugin-transform-computed-properties": "7.2.0",
+        "@babel/plugin-transform-destructuring": "7.4.4",
+        "@babel/plugin-transform-dotall-regex": "7.4.4",
+        "@babel/plugin-transform-duplicate-keys": "7.2.0",
+        "@babel/plugin-transform-exponentiation-operator": "7.2.0",
+        "@babel/plugin-transform-for-of": "7.4.4",
+        "@babel/plugin-transform-function-name": "7.4.4",
+        "@babel/plugin-transform-literals": "7.2.0",
+        "@babel/plugin-transform-member-expression-literals": "7.2.0",
+        "@babel/plugin-transform-modules-amd": "7.2.0",
+        "@babel/plugin-transform-modules-commonjs": "7.4.4",
+        "@babel/plugin-transform-modules-systemjs": "7.4.4",
+        "@babel/plugin-transform-modules-umd": "7.2.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "7.4.4",
+        "@babel/plugin-transform-new-target": "7.4.4",
+        "@babel/plugin-transform-object-super": "7.2.0",
+        "@babel/plugin-transform-parameters": "7.4.4",
+        "@babel/plugin-transform-property-literals": "7.2.0",
+        "@babel/plugin-transform-regenerator": "7.4.4",
+        "@babel/plugin-transform-reserved-words": "7.2.0",
+        "@babel/plugin-transform-shorthand-properties": "7.2.0",
+        "@babel/plugin-transform-spread": "7.2.2",
+        "@babel/plugin-transform-sticky-regex": "7.2.0",
+        "@babel/plugin-transform-template-literals": "7.4.4",
+        "@babel/plugin-transform-typeof-symbol": "7.2.0",
+        "@babel/plugin-transform-unicode-regex": "7.4.4",
+        "@babel/types": "7.4.4",
+        "browserslist": "4.6.0",
+        "core-js-compat": "3.0.1",
+        "invariant": "2.2.4",
+        "js-levenshtein": "1.1.6",
+        "semver": "5.5.0"
       }
     },
     "@babel/runtime": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
-      "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+      "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "0.13.2"
       }
     },
     "@babel/template": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
-      "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.4.4",
+        "@babel/types": "7.4.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
-      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+      "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.0",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.0",
-        "@babel/parser": "^7.4.3",
-        "@babel/types": "^7.4.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.4.4",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.4.4",
+        "@babel/parser": "7.4.4",
+        "@babel/types": "7.4.4",
+        "debug": "4.1.1",
+        "globals": "11.12.0",
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "debug": {
@@ -970,7 +970,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "lodash": {
@@ -988,14 +988,14 @@
       }
     },
     "@babel/types": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "2.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -1012,6 +1012,12 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/symlink-or-copy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
+      "integrity": "sha512-Lja2xYuuf2B3knEsga8ShbOdsfNOtzT73GyJmZyY7eGl2+ajOqrs8yM5ze0fsSoYwvA6bw7/Qr7OZ7PEEmYwWg==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1024,7 +1030,7 @@
       "integrity": "sha1-krHbDU89tHsFMN9uFa6X21FNwvg=",
       "dev": true,
       "requires": {
-        "mime": "~1.2.11",
+        "mime": "1.2.11",
         "negotiator": "0.4.6"
       }
     },
@@ -1040,8 +1046,8 @@
       "integrity": "sha512-26qTEWqZQ+cxSYygZ4Cf8tsjDBLceJahhtewxtKZA3SRa4PluuqYCuheemDQD+7Mf5B7sr+zhTDWAHDh02a1Dw==",
       "dev": true,
       "requires": {
-        "ensure-posix-path": "^1.0.1",
-        "object-hash": "^1.3.1"
+        "ensure-posix-path": "1.0.2",
+        "object-hash": "1.3.1"
       }
     },
     "amdefine": {
@@ -1068,8 +1074,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "aproba": {
@@ -1084,8 +1090,8 @@
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -1100,13 +1106,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -1115,7 +1121,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -1126,7 +1132,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -1135,7 +1141,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -1216,13 +1222,13 @@
       "integrity": "sha512-qsIvGJ/XYZ5bSGf5vHt2aEQHZnyuehmk/+51rCJhpkZl4LtvOZ+STbhLbdFAJGYO+dLzUT5Bb4nLKqHBX83vhw==",
       "dev": true,
       "requires": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
+        "debug": "2.6.9",
+        "heimdalljs": "0.2.6",
         "istextorbinary": "2.1.0",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.5.3",
-        "rsvp": "^3.0.18",
-        "username-sync": "^1.0.2"
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.3",
+        "rsvp": "3.6.2",
+        "username-sync": "1.0.2"
       },
       "dependencies": {
         "debug": {
@@ -1235,17 +1241,17 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -1254,7 +1260,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -1263,7 +1269,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.4"
           }
         }
       }
@@ -1281,13 +1287,13 @@
       "dev": true
     },
     "async-promise-queue": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
-      "integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.5.tgz",
+      "integrity": "sha512-xi0aQ1rrjPWYmqbwr18rrSKbSaXIeIwSd1J4KAgVfkq8utNbdZoht7GfvfY6swFUAMJ9obkc4WPJmtGwl+B8dw==",
       "dev": true,
       "requires": {
-        "async": "^2.4.1",
-        "debug": "^2.6.8"
+        "async": "2.6.2",
+        "debug": "2.6.9"
       },
       "dependencies": {
         "async": {
@@ -1296,7 +1302,7 @@
           "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "4.17.11"
           }
         },
         "debug": {
@@ -1329,21 +1335,21 @@
       "dev": true
     },
     "babel-plugin-debug-macros": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.0.tgz",
-      "integrity": "sha512-D6qYBI/3+FvcKVnRnH6FBUwXPp/5o/jnJNVFKqVaZpYAWx88+R8jNNyaEX7iQFs7UfCib6rcY/9+ICR4jhjFCQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.1.tgz",
+      "integrity": "sha512-1tnO63L4d9HFHguR4Xc+/Y7Og1+mDsXwiStVrsayyXIDauv6r1o9dnhRKPmmCV5digG2XgScnQJpWDsxNNLU7g==",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.5.0"
       }
     },
     "babel-plugin-ember-modules-api-polyfill": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.8.0.tgz",
-      "integrity": "sha512-3dlBH92qx8so2pRoks73+gwnuX97d0ajirOr96GwTZMnZxFzVR02c/PQbKWBcxpPqoL8CJSE2onuWM8PWezhOQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz",
+      "integrity": "sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==",
       "dev": true,
       "requires": {
-        "ember-rfc176-data": "^0.3.8"
+        "ember-rfc176-data": "0.3.9"
       }
     },
     "babel-plugin-module-resolver": {
@@ -1352,25 +1358,25 @@
       "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
       "dev": true,
       "requires": {
-        "find-babel-config": "^1.1.0",
-        "glob": "^7.1.2",
-        "pkg-up": "^2.0.0",
-        "reselect": "^3.0.1",
-        "resolve": "^1.4.0"
+        "find-babel-config": "1.2.0",
+        "glob": "7.1.4",
+        "pkg-up": "2.0.0",
+        "reselect": "3.0.1",
+        "resolve": "1.10.1"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -1379,7 +1385,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "path-parse": {
@@ -1389,12 +1395,12 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "path-parse": "1.0.6"
           }
         }
       }
@@ -1405,7 +1411,7 @@
       "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
       "dev": true,
       "requires": {
-        "underscore": ">=1.8.3"
+        "underscore": "1.9.1"
       },
       "dependencies": {
         "underscore": {
@@ -1434,13 +1440,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "component-emitter": {
@@ -1455,7 +1461,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1464,7 +1470,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1473,7 +1479,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1482,9 +1488,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -1571,15 +1577,15 @@
       "dev": true,
       "requires": {
         "bytes": "2.2.0",
-        "content-type": "~1.0.1",
-        "debug": "~2.2.0",
-        "depd": "~1.1.0",
-        "http-errors": "~1.3.1",
+        "content-type": "1.0.4",
+        "debug": "2.2.0",
+        "depd": "1.1.2",
+        "http-errors": "1.3.1",
         "iconv-lite": "0.4.13",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "5.2.0",
-        "raw-body": "~2.1.5",
-        "type-is": "~1.6.10"
+        "raw-body": "2.1.7",
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "bytes": {
@@ -1623,7 +1629,7 @@
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "dev": true,
       "requires": {
-        "hoek": "0.9.x"
+        "hoek": "0.9.1"
       },
       "dependencies": {
         "hoek": {
@@ -1640,7 +1646,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1650,9 +1656,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "broccoli-babel-transpiler": {
@@ -1661,17 +1667,17 @@
       "integrity": "sha512-lkP9dNFfK810CRHHWsNl9rjyYqcXH3qg0kArnA6tV9Owx3nlZm3Eyr0cGo6sMUQCNLH+2oKrRjOdUGSc6Um6Cw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.3.3",
-        "@babel/polyfill": "^7.0.0",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-merge-trees": "^3.0.2",
-        "broccoli-persistent-filter": "^2.2.1",
-        "clone": "^2.1.2",
-        "hash-for-dep": "^1.4.7",
-        "heimdalljs-logger": "^0.1.9",
-        "json-stable-stringify": "^1.0.1",
-        "rsvp": "^4.8.4",
-        "workerpool": "^3.1.1"
+        "@babel/core": "7.4.4",
+        "@babel/polyfill": "7.4.4",
+        "broccoli-funnel": "2.0.2",
+        "broccoli-merge-trees": "3.0.2",
+        "broccoli-persistent-filter": "2.2.3",
+        "clone": "2.1.2",
+        "hash-for-dep": "1.5.1",
+        "heimdalljs-logger": "0.1.10",
+        "json-stable-stringify": "1.0.1",
+        "rsvp": "4.8.4",
+        "workerpool": "3.1.2"
       },
       "dependencies": {
         "rsvp": {
@@ -1688,12 +1694,12 @@
       "integrity": "sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==",
       "dev": true,
       "requires": {
-        "broccoli-plugin": "^1.2.1",
-        "fs-tree-diff": "^0.5.2",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "symlink-or-copy": "^1.1.8",
-        "tree-sync": "^1.2.2"
+        "broccoli-plugin": "1.3.1",
+        "fs-tree-diff": "0.5.9",
+        "heimdalljs": "0.2.6",
+        "heimdalljs-logger": "0.1.10",
+        "symlink-or-copy": "1.2.0",
+        "tree-sync": "1.4.0"
       }
     },
     "broccoli-funnel": {
@@ -1702,19 +1708,19 @@
       "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
       "dev": true,
       "requires": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
+        "array-equal": "1.0.0",
+        "blank-object": "1.0.2",
+        "broccoli-plugin": "1.3.1",
+        "debug": "2.6.9",
+        "fast-ordered-set": "1.0.3",
+        "fs-tree-diff": "0.5.9",
+        "heimdalljs": "0.2.6",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "path-posix": "1.0.0",
+        "rimraf": "2.6.3",
+        "symlink-or-copy": "1.2.0",
+        "walk-sync": "0.3.2"
       },
       "dependencies": {
         "debug": {
@@ -1727,17 +1733,17 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -1746,7 +1752,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -1755,7 +1761,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.4"
           }
         }
       }
@@ -1766,8 +1772,8 @@
       "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
       "dev": true,
       "requires": {
-        "glob": "^5.0.10",
-        "mkdirp": "^0.5.1"
+        "glob": "5.0.15",
+        "mkdirp": "0.5.1"
       },
       "dependencies": {
         "glob": {
@@ -1776,11 +1782,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -1789,7 +1795,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -1800,29 +1806,29 @@
       "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
       "dev": true,
       "requires": {
-        "broccoli-plugin": "^1.3.0",
-        "merge-trees": "^2.0.0"
+        "broccoli-plugin": "1.3.1",
+        "merge-trees": "2.0.0"
       }
     },
     "broccoli-persistent-filter": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.2.2.tgz",
-      "integrity": "sha512-PW12RD1yY+x5SASUADuUMJce+dVSmjBO3pV1rLNHmT1C31rp1P++TvX7AgUObFmGhL7qlwviSdhMbBkY1v3G2w==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.2.3.tgz",
+      "integrity": "sha512-WSq6S9lC78LZ2T6L8s+NueEDuWdVSDiwjH8XbHo4ocL7V5fZLXupxvnPWtoH2Jp20j6/nvznTkgKJC4g70JVdA==",
       "dev": true,
       "requires": {
-        "async-disk-cache": "^1.2.1",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^1.0.0",
-        "fs-tree-diff": "^1.0.2",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "mkdirp": "^0.5.1",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^2.6.1",
-        "rsvp": "^4.7.0",
-        "symlink-or-copy": "^1.0.1",
-        "walk-sync": "^1.0.0"
+        "async-disk-cache": "1.3.4",
+        "async-promise-queue": "1.0.5",
+        "broccoli-plugin": "1.3.1",
+        "fs-tree-diff": "2.0.1",
+        "hash-for-dep": "1.5.1",
+        "heimdalljs": "0.2.6",
+        "heimdalljs-logger": "0.1.10",
+        "mkdirp": "0.5.1",
+        "promise-map-series": "0.2.3",
+        "rimraf": "2.6.3",
+        "rsvp": "4.8.4",
+        "symlink-or-copy": "1.2.0",
+        "walk-sync": "1.1.3"
       },
       "dependencies": {
         "ensure-posix-path": {
@@ -1832,29 +1838,30 @@
           "dev": true
         },
         "fs-tree-diff": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-1.0.2.tgz",
-          "integrity": "sha512-Zro2ACaPVDgVOx9+s5s5AfPlAD0kMJdbwGvTGF6KC1SjxjiGWxJvV4mUTDkFVSy3OUw2C/f1qpdjF81hGqSBAw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
           "dev": true,
           "requires": {
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
+            "@types/symlink-or-copy": "1.2.0",
+            "heimdalljs-logger": "0.1.10",
+            "object-assign": "4.1.1",
+            "path-posix": "1.0.0",
+            "symlink-or-copy": "1.2.0"
           }
         },
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "matcher-collection": {
@@ -1863,7 +1870,7 @@
           "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
           "dev": true,
           "requires": {
-            "minimatch": "^3.0.2"
+            "minimatch": "3.0.4"
           }
         },
         "minimatch": {
@@ -1872,7 +1879,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -1881,7 +1888,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.4"
           }
         },
         "rsvp": {
@@ -1896,9 +1903,9 @@
           "integrity": "sha512-23ivbET0Q/389y3EHpiIgxx881AS2mwdXA7iBqUDNSymoTPYb2jWlF3gkuuAP1iLgdNXmiHw/kZ/wZwrELU6Ag==",
           "dev": true,
           "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^1.1.1"
+            "@types/minimatch": "3.0.3",
+            "ensure-posix-path": "1.1.1",
+            "matcher-collection": "1.1.2"
           }
         }
       }
@@ -1909,24 +1916,24 @@
       "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
       "dev": true,
       "requires": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
+        "promise-map-series": "0.2.3",
+        "quick-temp": "0.1.8",
+        "rimraf": "2.6.3",
+        "symlink-or-copy": "1.2.0"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -1935,7 +1942,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -1944,7 +1951,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.4"
           }
         }
       }
@@ -1956,14 +1963,14 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-      "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.0.tgz",
+      "integrity": "sha512-Jk0YFwXBuMOOol8n6FhgkDzn3mY9PYLYGk29zybF05SbRTsMgPqmTNeQQhOghCxq5oFqAXE3u4sYddr4C0uRhg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000955",
-        "electron-to-chromium": "^1.3.122",
-        "node-releases": "^1.1.13"
+        "caniuse-lite": "1.0.30000967",
+        "electron-to-chromium": "1.3.133",
+        "node-releases": "1.1.19"
       }
     },
     "buffer-crc32": {
@@ -1990,15 +1997,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "component-emitter": {
@@ -2033,8 +2040,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "can-symlink": {
@@ -2047,9 +2054,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000957",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000957.tgz",
-      "integrity": "sha512-8wxNrjAzyiHcLXN/iunskqQnJquQQ6VX8JHfW5kLgAPRSiSuKZiNfmIkP5j7jgyXqAQBSoXyJxfnbCFS0ThSiQ==",
+      "version": "1.0.30000967",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000967.tgz",
+      "integrity": "sha512-rUBIbap+VJfxTzrM4akJ00lkvVb5/n5v3EGXfWzSH5zT8aJmGzjA8HWhJ4U6kCpzxozUSnB+yvAYDRPY6mRpgQ==",
       "dev": true
     },
     "chalk": {
@@ -2058,11 +2065,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "charm": {
@@ -2071,7 +2078,7 @@
       "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "chokidar": {
@@ -2080,15 +2087,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.3",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "class-utils": {
@@ -2097,10 +2104,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -2109,7 +2116,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "isobject": {
@@ -2133,7 +2140,7 @@
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "^7.1.1"
+        "glob": "7.1.3"
       },
       "dependencies": {
         "glob": {
@@ -2142,12 +2149,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -2156,7 +2163,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -2191,8 +2198,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -2292,7 +2299,7 @@
         "bytes": "0.2.0",
         "cookie": "0.0.5",
         "cookie-signature": "1.0.1",
-        "debug": "*",
+        "debug": "3.1.0",
         "formidable": "1.0.14",
         "fresh": "0.1.0",
         "pause": "0.0.1",
@@ -2323,7 +2330,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "console-control-strings": {
@@ -2338,7 +2345,7 @@
       "integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.1.1"
+        "bluebird": "3.5.4"
       }
     },
     "content-disposition": {
@@ -2359,7 +2366,7 @@
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "cookie": {
@@ -2428,10 +2435,10 @@
       "integrity": "sha512-2pC3e+Ht/1/gD7Sim/sqzvRplMiRnFQVlPpDVaHtY9l7zZP7knamr3VRD6NyGfHd84MrDC0tAM9ulNxYMW0T3g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.5.4",
+        "browserslist": "4.6.0",
         "core-js": "3.0.1",
         "core-js-pure": "3.0.1",
-        "semver": "^6.0.0"
+        "semver": "6.0.0"
       },
       "dependencies": {
         "core-js": {
@@ -2466,11 +2473,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.5.0",
+        "shebang-command": "1.2.0",
+        "which": "1.2.14"
       }
     },
     "cryptiles": {
@@ -2479,7 +2486,7 @@
       "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
       "dev": true,
       "requires": {
-        "boom": "0.4.x"
+        "boom": "0.4.2"
       }
     },
     "csrf-tokens": {
@@ -2488,9 +2495,9 @@
       "integrity": "sha1-SWclaLJwM0hkTqyvYc29wFS6VvI=",
       "dev": true,
       "requires": {
-        "rndm": "1",
-        "scmp": "~0.0.3",
-        "uid2": "~0.0.2"
+        "rndm": "1.2.0",
+        "scmp": "0.0.3",
+        "uid2": "0.0.3"
       }
     },
     "csurf": {
@@ -2499,7 +2506,7 @@
       "integrity": "sha1-OSj6I3WS7Vgkp8Ih2Fgb81ap2nY=",
       "dev": true,
       "requires": {
-        "csrf-tokens": "~1.0.2"
+        "csrf-tokens": "1.0.4"
       }
     },
     "ctype": {
@@ -2514,7 +2521,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "date-now": {
@@ -2529,8 +2536,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1",
-        "meow": "^3.3.0"
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
       }
     },
     "debug": {
@@ -2560,8 +2567,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -2570,7 +2577,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2579,7 +2586,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2588,9 +2595,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -2643,8 +2650,8 @@
       "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
+        "domelementtype": "1.3.1",
+        "entities": "1.1.2"
       },
       "dependencies": {
         "entities": {
@@ -2667,7 +2674,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.1"
       }
     },
     "domutils": {
@@ -2676,8 +2683,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.1",
+        "domelementtype": "1.3.1"
       }
     },
     "editions": {
@@ -2693,9 +2700,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.124",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz",
-      "integrity": "sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==",
+      "version": "1.3.133",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.133.tgz",
+      "integrity": "sha512-lyoC8aoqbbDqsprb6aPdt9n3DpOZZzdz/T4IZKsR0/dkZIxnJVUjjcpOSwA66jPRIOyDAamCTAUqweU05kKNSg==",
       "dev": true
     },
     "ember-cli-babel": {
@@ -2704,27 +2711,54 @@
       "integrity": "sha512-/LWwyKIoSlZQ7k52P+6agC7AhcOBqPJ5C2u27qXHVVxKvCtg6ahNuRk/KmfZmV4zkuw4EjTZxfJE1PzpFyHkXg==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.0.0",
-        "@babel/plugin-proposal-class-properties": "^7.3.4",
-        "@babel/plugin-proposal-decorators": "^7.3.0",
-        "@babel/plugin-transform-modules-amd": "^7.0.0",
-        "@babel/plugin-transform-runtime": "^7.2.0",
-        "@babel/polyfill": "^7.0.0",
-        "@babel/preset-env": "^7.0.0",
-        "@babel/runtime": "^7.2.0",
-        "amd-name-resolver": "^1.2.1",
-        "babel-plugin-debug-macros": "^0.3.0",
-        "babel-plugin-ember-modules-api-polyfill": "^2.8.0",
-        "babel-plugin-module-resolver": "^3.1.1",
-        "broccoli-babel-transpiler": "^7.1.2",
-        "broccoli-debug": "^0.6.4",
-        "broccoli-funnel": "^2.0.1",
-        "broccoli-source": "^1.1.0",
-        "clone": "^2.1.2",
-        "ember-cli-babel-plugin-helpers": "^1.1.0",
-        "ember-cli-version-checker": "^2.1.2",
-        "ensure-posix-path": "^1.0.2",
-        "semver": "^5.5.0"
+        "@babel/core": "7.4.4",
+        "@babel/plugin-proposal-class-properties": "7.4.4",
+        "@babel/plugin-proposal-decorators": "7.4.4",
+        "@babel/plugin-transform-modules-amd": "7.2.0",
+        "@babel/plugin-transform-runtime": "7.4.4",
+        "@babel/polyfill": "7.4.4",
+        "@babel/preset-env": "7.4.4",
+        "@babel/runtime": "7.4.4",
+        "amd-name-resolver": "1.3.1",
+        "babel-plugin-debug-macros": "0.3.1",
+        "babel-plugin-ember-modules-api-polyfill": "2.9.0",
+        "babel-plugin-module-resolver": "3.2.0",
+        "broccoli-babel-transpiler": "7.2.0",
+        "broccoli-debug": "0.6.5",
+        "broccoli-funnel": "2.0.2",
+        "broccoli-source": "1.1.0",
+        "clone": "2.1.2",
+        "ember-cli-babel-plugin-helpers": "1.1.0",
+        "ember-cli-version-checker": "2.2.0",
+        "ensure-posix-path": "1.0.2",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
+          "requires": {
+            "resolve": "1.10.1",
+            "semver": "5.5.0"
+          }
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.6"
+          }
+        }
       }
     },
     "ember-cli-babel-plugin-helpers": {
@@ -2751,7 +2785,7 @@
       "integrity": "sha1-CxT3vLxZmqEXtf3cgeT9A8S61bc=",
       "dev": true,
       "requires": {
-        "silent-error": "^1.0.0"
+        "silent-error": "1.1.1"
       }
     },
     "ember-cli-path-utils": {
@@ -2767,36 +2801,27 @@
       "dev": true
     },
     "ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+      "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
       "dev": true,
       "requires": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
+        "resolve-package-path": "1.2.7",
+        "semver": "5.7.0"
       },
       "dependencies": {
-        "path-parse": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
-        },
-        "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
         }
       }
     },
     "ember-rfc176-data": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.8.tgz",
-      "integrity": "sha512-SQup3iG7SDLZNuf7nMMx5BC5truO8AYKRi80gApeQ07NsbuXV4LH75i5eOaxF0i8l9+H1tzv34kGe6rEh0C1NQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.9.tgz",
+      "integrity": "sha512-EiTo5YQS0Duy0xp9gCP8ekzv9vxirNi7MnIB4zWs+thtWp/mEKgf5mkiiLU2+oo8C5DuavVHhoPQDmyxh8Io1Q==",
       "dev": true
     },
     "ember-router-generator": {
@@ -2805,29 +2830,29 @@
       "integrity": "sha1-jtLKhv8yM2MSD8FCeBkeno8TFe4=",
       "dev": true,
       "requires": {
-        "recast": "^0.11.3"
+        "recast": "0.11.23"
       }
     },
     "ember-source": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.8.1.tgz",
-      "integrity": "sha512-dzz2i2XUY+yqxVIoV8V0B6lIGjtWVJLHtsid2MkDfaJl2GRcsioYVmv20Elyhny0oGBRJY8ESbODULkKoY9Urw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.10.0.tgz",
+      "integrity": "sha512-qHI+1y1gcfHO44+Ld3ty9565UsqlmimfOLe/Ra3jA4Z9h6vJNOdIzr4Bws7by/8kiBqjO1RM+TVe19zglivwoQ==",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "^2.0.1",
-        "broccoli-merge-trees": "^3.0.2",
-        "chalk": "^2.3.0",
-        "ember-cli-babel": "^7.2.0",
-        "ember-cli-get-component-path-option": "^1.0.0",
-        "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-path-utils": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-router-generator": "^1.2.3",
-        "inflection": "^1.12.0",
-        "jquery": "^3.3.1",
-        "resolve": "^1.9.0"
+        "broccoli-funnel": "2.0.2",
+        "broccoli-merge-trees": "3.0.2",
+        "chalk": "2.4.2",
+        "ember-cli-babel": "7.7.3",
+        "ember-cli-get-component-path-option": "1.0.0",
+        "ember-cli-is-package-missing": "1.0.0",
+        "ember-cli-normalize-entity-name": "1.0.0",
+        "ember-cli-path-utils": "1.0.0",
+        "ember-cli-string-utils": "1.1.0",
+        "ember-cli-version-checker": "3.1.3",
+        "ember-router-generator": "1.2.3",
+        "inflection": "1.12.0",
+        "jquery": "3.4.1",
+        "resolve": "1.10.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2836,7 +2861,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "chalk": {
@@ -2845,9 +2870,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "path-parse": {
@@ -2857,12 +2882,12 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "path-parse": "1.0.6"
           }
         },
         "supports-color": {
@@ -2871,7 +2896,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2888,7 +2913,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "engine.io": {
@@ -2897,12 +2922,12 @@
       "integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~6.1.0"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.3",
+        "ws": "6.1.4"
       },
       "dependencies": {
         "accepts": {
@@ -2911,7 +2936,7 @@
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
           "requires": {
-            "mime-types": "~2.1.18",
+            "mime-types": "2.1.18",
             "negotiator": "0.6.1"
           }
         },
@@ -2937,14 +2962,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.3",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~6.1.0",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "6.1.4",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       }
     },
@@ -2955,10 +2980,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.5",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.3"
       }
     },
     "ensure-posix-path": {
@@ -2979,7 +3004,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "errorhandler": {
@@ -3042,13 +3067,13 @@
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "6.0.5",
+        "get-stream": "4.1.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "exists-stat": {
@@ -3069,7 +3094,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -3078,7 +3103,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.3"
       }
     },
     "expand-tilde": {
@@ -3087,7 +3112,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "express": {
@@ -3096,36 +3121,36 @@
       "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.3",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
+        "proxy-addr": "2.0.4",
         "qs": "6.5.2",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.2",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "accepts": {
@@ -3134,7 +3159,7 @@
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
           "requires": {
-            "mime-types": "~2.1.18",
+            "mime-types": "2.1.18",
             "negotiator": "0.6.1"
           }
         },
@@ -3145,15 +3170,15 @@
           "dev": true,
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "~1.0.4",
+            "content-type": "1.0.4",
             "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "http-errors": "~1.6.3",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
             "iconv-lite": "0.4.23",
-            "on-finished": "~2.3.0",
+            "on-finished": "2.3.0",
             "qs": "6.5.2",
             "raw-body": "2.3.3",
-            "type-is": "~1.6.16"
+            "type-is": "1.6.16"
           }
         },
         "bytes": {
@@ -3201,10 +3226,10 @@
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "statuses": "1.4.0"
           }
         },
         "iconv-lite": {
@@ -3213,7 +3238,7 @@
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "mime": {
@@ -3265,18 +3290,18 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "destroy": "~1.0.4",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "~1.6.2",
+            "http-errors": "1.6.3",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.2.0",
-            "statuses": "~1.4.0"
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.4.0"
           }
         },
         "serve-static": {
@@ -3285,9 +3310,9 @@
           "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
           "dev": true,
           "requires": {
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "parseurl": "~1.3.2",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.2",
             "send": "0.16.2"
           }
         },
@@ -3352,8 +3377,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3362,7 +3387,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -3373,7 +3398,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "falafel": {
@@ -3382,7 +3407,7 @@
       "integrity": "sha1-MITPPUG1nRXIE75vJZVX/cgrBmA=",
       "dev": true,
       "requires": {
-        "esprima": "~1.0.2"
+        "esprima": "1.0.4"
       },
       "dependencies": {
         "esprima": {
@@ -3399,7 +3424,7 @@
       "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
       "dev": true,
       "requires": {
-        "blank-object": "^1.0.1"
+        "blank-object": "1.0.2"
       }
     },
     "faye-websocket": {
@@ -3408,7 +3433,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "filename-regex": {
@@ -3423,11 +3448,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "finalhandler": {
@@ -3437,12 +3462,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -3468,8 +3493,8 @@
       "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
       "dev": true,
       "requires": {
-        "json5": "^0.5.1",
-        "path-exists": "^3.0.0"
+        "json5": "0.5.1",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "json5": {
@@ -3492,8 +3517,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "findup-sync": {
@@ -3502,7 +3527,7 @@
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
-        "glob": "~5.0.0"
+        "glob": "5.0.15"
       },
       "dependencies": {
         "glob": {
@@ -3511,11 +3536,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -3524,7 +3549,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -3552,11 +3577,11 @@
       "integrity": "sha1-zPIPeUHxCIg/zduZOD2+bhhhx1g=",
       "dev": true,
       "requires": {
-        "async": "~0.2.9",
+        "async": "0.2.10",
         "is-type": "0.0.1",
-        "lodash.debounce": "^3.1.1",
-        "lodash.flatten": "^3.0.2",
-        "minimatch": "^3.0.2"
+        "lodash.debounce": "3.1.1",
+        "lodash.flatten": "3.0.2",
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "async": {
@@ -3571,7 +3596,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -3582,7 +3607,7 @@
       "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "dev": true,
       "requires": {
-        "debug": "^3.2.6"
+        "debug": "3.2.6"
       },
       "dependencies": {
         "debug": {
@@ -3591,7 +3616,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "ms": {
@@ -3614,7 +3639,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "forever-agent": {
@@ -3629,9 +3654,9 @@
       "integrity": "sha1-CJDNEAXFzOzAudJKiAUskkQtDbU=",
       "dev": true,
       "requires": {
-        "async": "~0.2.7",
-        "combined-stream": "~0.0.4",
-        "mime": "~1.2.2"
+        "async": "0.2.10",
+        "combined-stream": "0.0.7",
+        "mime": "1.2.11"
       },
       "dependencies": {
         "async": {
@@ -3660,7 +3685,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -3675,8 +3700,8 @@
       "integrity": "sha1-ZKYzkRn42mh75NH9vaN+4PiOZEw=",
       "dev": true,
       "requires": {
-        "async": "~ 0.2.9",
-        "lodash": "~ 2.4.1"
+        "async": "0.2.10",
+        "lodash": "2.4.2"
       },
       "dependencies": {
         "async": {
@@ -3699,10 +3724,10 @@
       "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
       "dev": true,
       "requires": {
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
+        "heimdalljs-logger": "0.1.10",
+        "object-assign": "4.1.1",
+        "path-posix": "1.0.0",
+        "symlink-or-copy": "1.2.0"
       }
     },
     "fs-updater": {
@@ -3711,25 +3736,25 @@
       "integrity": "sha512-0pJX4mJF/qLsNEwTct8CdnnRdagfb+LmjRPJ8sO+nCnAZLW0cTmz4rTgU25n+RvTuWSITiLKrGVJceJPBIPlKg==",
       "dev": true,
       "requires": {
-        "can-symlink": "^1.0.0",
-        "clean-up-path": "^1.0.0",
-        "heimdalljs": "^0.2.5",
-        "heimdalljs-logger": "^0.1.9",
-        "rimraf": "^2.6.2"
+        "can-symlink": "1.0.0",
+        "clean-up-path": "1.0.0",
+        "heimdalljs": "0.2.6",
+        "heimdalljs-logger": "0.1.10",
+        "rimraf": "2.6.3"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -3738,7 +3763,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -3747,7 +3772,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.4"
           }
         }
       }
@@ -3765,181 +3790,207 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.3.0",
-        "node-pre-gyp": "^0.6.39"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
           "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
           }
         },
         "asn1": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           }
         },
         "block-stream": {
           "version": "0.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.0"
+            "inherits": "2.0.3"
           }
         },
         "boom": {
           "version": "2.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "dev": true,
           "requires": {
-            "balanced-match": "^0.4.1",
+            "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
           }
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -3947,7 +3998,8 @@
         },
         "debug": {
           "version": "2.6.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3956,119 +4008,134 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+          "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "extend": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
           }
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "inherits": "2",
-            "minimatch": "^3.0.0"
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
           }
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -4076,161 +4143,183 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
           "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
           }
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
           "version": "2.16.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
           }
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
+            "jsbn": "0.1.1"
           }
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4242,7 +4331,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -4250,33 +4340,38 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "dev": true,
           "requires": {
-            "mime-db": "~1.27.0"
+            "mime-db": "1.27.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -4284,141 +4379,159 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
+            "detect-libc": "1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
             "request": "2.81.0",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
           }
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
           }
         },
         "npmlog": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -4426,107 +4539,117 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
           "dev": true,
           "requires": {
-            "buffer-shims": "~1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "request": {
           "version": "2.81.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
           }
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "sshpk": {
           "version": "1.13.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jodid25519": "^1.0.0",
-            "jsbn": "~0.1.0",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
           },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -4534,112 +4657,126 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
           "version": "0.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         },
         "tar-pack": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.2.0",
-            "fstream": "^1.0.10",
-            "fstream-ignore": "^1.0.5",
-            "once": "^1.3.3",
-            "readable-stream": "^2.1.4",
-            "rimraf": "^2.5.1",
-            "tar": "^2.2.1",
-            "uid-number": "^0.0.6"
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
           }
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "^1.4.1"
+            "punycode": "1.4.1"
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.0.1"
           }
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -4648,16 +4785,18 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }
       }
@@ -4668,14 +4807,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
       }
     },
     "gaze": {
@@ -4684,7 +4823,7 @@
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
-        "globule": "^1.0.0"
+        "globule": "1.2.0"
       }
     },
     "get-stdin": {
@@ -4699,7 +4838,7 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "requires": {
-        "pump": "^3.0.0"
+        "pump": "3.0.0"
       }
     },
     "get-value": {
@@ -4720,8 +4859,8 @@
       "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
       "dev": true,
       "requires": {
-        "inherits": "2",
-        "minimatch": "0.3"
+        "inherits": "2.0.3",
+        "minimatch": "0.3.0"
       }
     },
     "glob-base": {
@@ -4730,8 +4869,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -4740,7 +4879,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "global-modules": {
@@ -4749,9 +4888,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -4760,17 +4899,17 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.2.14"
       }
     },
     "globals": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
     "globule": {
@@ -4779,9 +4918,9 @@
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
-        "glob": "~7.1.1",
-        "lodash": "~4.17.4",
-        "minimatch": "~3.0.2"
+        "glob": "7.1.2",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "glob": {
@@ -4790,12 +4929,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "lodash": {
@@ -4810,7 +4949,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -4833,22 +4972,22 @@
       "integrity": "sha1-TmpeaVtwRy/VME9fqeNCNoNqc7w=",
       "dev": true,
       "requires": {
-        "coffeescript": "~1.10.0",
-        "dateformat": "~1.0.12",
-        "eventemitter2": "~0.4.13",
-        "exit": "~0.1.1",
-        "findup-sync": "~0.3.0",
-        "glob": "~7.0.0",
-        "grunt-cli": "~1.2.0",
-        "grunt-known-options": "~1.1.0",
-        "grunt-legacy-log": "~1.0.0",
-        "grunt-legacy-util": "~1.0.0",
-        "iconv-lite": "~0.4.13",
-        "js-yaml": "~3.5.2",
-        "minimatch": "~3.0.2",
-        "nopt": "~3.0.6",
-        "path-is-absolute": "~1.0.0",
-        "rimraf": "~2.2.8"
+        "coffeescript": "1.10.0",
+        "dateformat": "1.0.12",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.3.0",
+        "glob": "7.0.6",
+        "grunt-cli": "1.2.0",
+        "grunt-known-options": "1.1.0",
+        "grunt-legacy-log": "1.0.0",
+        "grunt-legacy-util": "1.0.0",
+        "iconv-lite": "0.4.19",
+        "js-yaml": "3.5.5",
+        "minimatch": "3.0.4",
+        "nopt": "3.0.6",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "glob": {
@@ -4857,12 +4996,12 @@
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "grunt-cli": {
@@ -4871,10 +5010,10 @@
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
           "dev": true,
           "requires": {
-            "findup-sync": "~0.3.0",
-            "grunt-known-options": "~1.1.0",
-            "nopt": "~3.0.6",
-            "resolve": "~1.1.0"
+            "findup-sync": "0.3.0",
+            "grunt-known-options": "1.1.0",
+            "nopt": "3.0.6",
+            "resolve": "1.1.7"
           }
         },
         "minimatch": {
@@ -4883,7 +5022,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -4900,7 +5039,7 @@
       "integrity": "sha1-H6JTU/GtgLeSKIdYI1+v+YtYPKU=",
       "dev": true,
       "requires": {
-        "connect": "~2.7.3"
+        "connect": "2.7.11"
       }
     },
     "grunt-contrib-copy": {
@@ -4915,8 +5054,8 @@
       "integrity": "sha1-9rLwb8cVJkg3p6tsaaHOGmicLCk=",
       "dev": true,
       "requires": {
-        "hooker": "^0.2.3",
-        "jshint": "~2.9.1"
+        "hooker": "0.2.3",
+        "jshint": "2.9.7"
       }
     },
     "grunt-contrib-uglify": {
@@ -4925,8 +5064,8 @@
       "integrity": "sha1-5r2lHgxAoUWfbOrUI8Ze/XJaG/c=",
       "dev": true,
       "requires": {
-        "grunt-lib-contrib": "~0.6.1",
-        "uglify-js": "~2.4.0"
+        "grunt-lib-contrib": "0.6.1",
+        "uglify-js": "2.4.24"
       }
     },
     "grunt-contrib-watch": {
@@ -4935,10 +5074,10 @@
       "integrity": "sha1-hKGnodar0m7VaEE0lscxM+mQAY8=",
       "dev": true,
       "requires": {
-        "async": "^1.5.0",
-        "gaze": "^1.0.0",
-        "lodash": "^3.10.1",
-        "tiny-lr": "^0.2.1"
+        "async": "1.5.2",
+        "gaze": "1.1.2",
+        "lodash": "3.10.1",
+        "tiny-lr": "0.2.1"
       }
     },
     "grunt-curl": {
@@ -4947,8 +5086,8 @@
       "integrity": "sha1-Is9fPNoHx6ybTS1rKCJqzFVJdkI=",
       "dev": true,
       "requires": {
-        "grunt-retro": "~0.6.0",
-        "request": "~2.21.0"
+        "grunt-retro": "0.6.4",
+        "request": "2.21.0"
       }
     },
     "grunt-ember-s3": {
@@ -4957,8 +5096,8 @@
       "integrity": "sha1-NUilok2BAUPqTbEsuQa+UmDMpJE=",
       "dev": true,
       "requires": {
-        "async": "~0.2.9",
-        "s3": "~0.3.0"
+        "async": "0.2.10",
+        "s3": "0.3.1"
       },
       "dependencies": {
         "async": {
@@ -4981,11 +5120,11 @@
       "integrity": "sha1-+4bxgJhHvAfcR4Q/ns1srLYt8tU=",
       "dev": true,
       "requires": {
-        "colors": "~1.1.2",
-        "grunt-legacy-log-utils": "~1.0.0",
-        "hooker": "~0.2.3",
-        "lodash": "~3.10.1",
-        "underscore.string": "~3.2.3"
+        "colors": "1.1.2",
+        "grunt-legacy-log-utils": "1.0.0",
+        "hooker": "0.2.3",
+        "lodash": "3.10.1",
+        "underscore.string": "3.2.3"
       }
     },
     "grunt-legacy-log-utils": {
@@ -4994,8 +5133,8 @@
       "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
       "dev": true,
       "requires": {
-        "chalk": "~1.1.1",
-        "lodash": "~4.3.0"
+        "chalk": "1.1.3",
+        "lodash": "4.3.0"
       },
       "dependencies": {
         "lodash": {
@@ -5012,13 +5151,13 @@
       "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
       "dev": true,
       "requires": {
-        "async": "~1.5.2",
-        "exit": "~0.1.1",
-        "getobject": "~0.1.0",
-        "hooker": "~0.2.3",
-        "lodash": "~4.3.0",
-        "underscore.string": "~3.2.3",
-        "which": "~1.2.1"
+        "async": "1.5.2",
+        "exit": "0.1.2",
+        "getobject": "0.1.0",
+        "hooker": "0.2.3",
+        "lodash": "4.3.0",
+        "underscore.string": "3.2.3",
+        "which": "1.2.14"
       },
       "dependencies": {
         "lodash": {
@@ -5044,8 +5183,8 @@
       "integrity": "sha1-h/h+11gqdTakmgt07aOeebicsbE=",
       "dev": true,
       "requires": {
-        "glob": "~3.2.3",
-        "source-map": "~0.1.22"
+        "glob": "3.2.11",
+        "source-map": "0.1.34"
       }
     },
     "grunt-release": {
@@ -5054,10 +5193,10 @@
       "integrity": "sha1-uNYAiJVhlm1g/9zAYGfrAVWX940=",
       "dev": true,
       "requires": {
-        "q": "^1.4.1",
-        "semver": "^5.1.0",
-        "shelljs": "^0.7.0",
-        "superagent": "^1.8.3"
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.7.8",
+        "superagent": "1.8.5"
       },
       "dependencies": {
         "glob": {
@@ -5066,12 +5205,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -5080,7 +5219,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "shelljs": {
@@ -5089,9 +5228,9 @@
           "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.0",
-            "interpret": "^1.0.0",
-            "rechoir": "^0.6.2"
+            "glob": "7.1.3",
+            "interpret": "1.2.0",
+            "rechoir": "0.6.2"
           }
         }
       }
@@ -5108,7 +5247,7 @@
       "integrity": "sha1-D6far6Citd/fvCYWeOp+LXUnpL8=",
       "dev": true,
       "requires": {
-        "falafel": "~0.1.3"
+        "falafel": "0.1.6"
       }
     },
     "grunt-strip-node": {
@@ -5117,19 +5256,18 @@
       "integrity": "sha1-++KNzKYlivr3Pw5pqJMTcIAn3Rw=",
       "dev": true,
       "requires": {
-        "falafel": "~0.1.3"
+        "falafel": "0.1.6"
       }
     },
     "grunt-testem-mincer": {
       "version": "github:patocallaghan/grunt-testem-mincer#1776e8dba749ec12a4b37a59d9863a352c29d9f3",
-      "from": "github:patocallaghan/grunt-testem-mincer#patoc/update-testem",
       "dev": true,
       "requires": {
-        "coffee-script": ">=1.6.3",
-        "connect": "~2.19.0",
-        "mincer": "~0.5.5",
-        "sugar": "~1.3.8",
-        "testem": "^2.0.0"
+        "coffee-script": "1.12.7",
+        "connect": "2.19.6",
+        "mincer": "0.5.13",
+        "sugar": "1.3.9",
+        "testem": "2.14.0"
       },
       "dependencies": {
         "body-parser": {
@@ -5242,7 +5380,7 @@
           "integrity": "sha1-mOnfmn4t+ZSTG3zbSyprlpSnTwI=",
           "dev": true,
           "requires": {
-            "bytes": "1"
+            "bytes": "1.0.0"
           }
         },
         "type-is": {
@@ -5262,7 +5400,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
@@ -5306,9 +5444,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -5325,8 +5463,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -5335,7 +5473,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5344,7 +5482,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5355,7 +5493,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5366,12 +5504,12 @@
       "integrity": "sha512-/dQ/A2cl7FBPI2pO0CANkvuuVi/IFS5oTyJ0PsOb6jW6WbVW1js5qJXMJTNbWHXBIPdFTWFbabjB+mE0d+gelw==",
       "dev": true,
       "requires": {
-        "broccoli-kitchen-sink-helpers": "^0.3.1",
-        "heimdalljs": "^0.2.3",
-        "heimdalljs-logger": "^0.1.7",
-        "path-root": "^0.1.1",
-        "resolve": "^1.10.0",
-        "resolve-package-path": "^1.0.11"
+        "broccoli-kitchen-sink-helpers": "0.3.1",
+        "heimdalljs": "0.2.6",
+        "heimdalljs-logger": "0.1.10",
+        "path-root": "0.1.1",
+        "resolve": "1.10.1",
+        "resolve-package-path": "1.2.7"
       },
       "dependencies": {
         "path-parse": {
@@ -5381,12 +5519,12 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "path-parse": "1.0.6"
           }
         }
       }
@@ -5397,10 +5535,10 @@
       "integrity": "sha1-NheViCH1gxHk1/beKR/KZitBLvQ=",
       "dev": true,
       "requires": {
-        "boom": "0.4.x",
-        "cryptiles": "0.2.x",
-        "hoek": "0.8.x",
-        "sntp": "0.2.x"
+        "boom": "0.4.2",
+        "cryptiles": "0.2.2",
+        "hoek": "0.8.5",
+        "sntp": "0.2.4"
       }
     },
     "heimdalljs": {
@@ -5409,7 +5547,7 @@
       "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
       "dev": true,
       "requires": {
-        "rsvp": "~3.2.1"
+        "rsvp": "3.2.1"
       },
       "dependencies": {
         "rsvp": {
@@ -5426,8 +5564,8 @@
       "integrity": "sha512-pO++cJbhIufVI/fmB/u2Yty3KJD0TqNPecehFae0/eps0hkZ3b4Zc/PezUMOpYuHFQbA7FxHZxa305EhmjLj4g==",
       "dev": true,
       "requires": {
-        "debug": "^2.2.0",
-        "heimdalljs": "^0.2.6"
+        "debug": "2.6.9",
+        "heimdalljs": "0.2.6"
       },
       "dependencies": {
         "debug": {
@@ -5447,7 +5585,7 @@
       "integrity": "sha1-06/Q4JIHnHsLLjw38uLJTqLGb14=",
       "dev": true,
       "requires": {
-        "lodash": "~ 2.4.1"
+        "lodash": "2.4.2"
       },
       "dependencies": {
         "lodash": {
@@ -5470,7 +5608,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hooker": {
@@ -5491,11 +5629,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.3",
-        "domutils": "1.5",
-        "entities": "1.0",
-        "readable-stream": "1.1"
+        "domelementtype": "1.3.1",
+        "domhandler": "2.3.0",
+        "domutils": "1.5.1",
+        "entities": "1.0.0",
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "readable-stream": {
@@ -5504,10 +5642,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         }
       }
@@ -5518,8 +5656,8 @@
       "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "statuses": "1"
+        "inherits": "2.0.3",
+        "statuses": "1.4.0"
       }
     },
     "http-parser-js": {
@@ -5534,9 +5672,9 @@
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
-        "eventemitter3": "^3.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.7.0",
+        "requires-port": "1.0.0"
       }
     },
     "http-signature": {
@@ -5562,7 +5700,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexof": {
@@ -5583,8 +5721,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -5611,7 +5749,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "ipaddr.js": {
@@ -5626,7 +5764,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-arrayish": {
@@ -5641,7 +5779,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -5656,7 +5794,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-data-descriptor": {
@@ -5665,7 +5803,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-descriptor": {
@@ -5674,9 +5812,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -5699,7 +5837,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -5720,7 +5858,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -5729,7 +5867,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-glob": {
@@ -5738,7 +5876,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-number": {
@@ -5747,7 +5885,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-odd": {
@@ -5756,7 +5894,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -5773,7 +5911,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -5808,7 +5946,7 @@
       "integrity": "sha1-9lHYXDZdRJVdFKUdjXBh8/a0d5w=",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0"
+        "core-util-is": "1.0.2"
       }
     },
     "is-utf8": {
@@ -5864,15 +6002,15 @@
       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
       "dev": true,
       "requires": {
-        "binaryextensions": "1 || 2",
-        "editions": "^1.1.1",
-        "textextensions": "1 || 2"
+        "binaryextensions": "2.1.2",
+        "editions": "1.3.4",
+        "textextensions": "2.4.0"
       }
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
       "dev": true
     },
     "js-levenshtein": {
@@ -5899,8 +6037,8 @@
       "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.2",
-        "esprima": "^2.6.0"
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
       }
     },
     "jsesc": {
@@ -5915,14 +6053,14 @@
       "integrity": "sha512-Q8XN38hGsVQhdlM+4gd1Xl7OB1VieSuCJf+fEJjpo59JH99bVJhXRXAh26qQ15wfdd1VPMuDWNeSWoNl53T4YA==",
       "dev": true,
       "requires": {
-        "cli": "~1.0.0",
-        "console-browserify": "1.1.x",
-        "exit": "0.1.x",
-        "htmlparser2": "3.8.x",
-        "lodash": "~4.17.10",
-        "minimatch": "~3.0.2",
-        "shelljs": "0.3.x",
-        "strip-json-comments": "1.0.x"
+        "cli": "1.0.1",
+        "console-browserify": "1.1.0",
+        "exit": "0.1.2",
+        "htmlparser2": "3.8.3",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "shelljs": "0.3.0",
+        "strip-json-comments": "1.0.4"
       },
       "dependencies": {
         "lodash": {
@@ -5937,7 +6075,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -5948,7 +6086,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -5963,7 +6101,7 @@
       "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "1.2.0"
       }
     },
     "jsonify": {
@@ -5978,7 +6116,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "knox": {
@@ -5987,10 +6125,10 @@
       "integrity": "sha1-ai7c2sHSrjedHhmU1Vm5XCg7JYg=",
       "dev": true,
       "requires": {
-        "debug": "~0.7.0",
-        "mime": "*",
-        "stream-counter": "~0.1.0",
-        "xml2js": "0.2.x"
+        "debug": "0.7.4",
+        "mime": "1.2.11",
+        "stream-counter": "0.1.0",
+        "xml2js": "0.2.8"
       },
       "dependencies": {
         "debug": {
@@ -6013,11 +6151,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       }
     },
     "locate-path": {
@@ -6026,8 +6164,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -6050,8 +6188,8 @@
       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
       "dev": true,
       "requires": {
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash._getnative": {
@@ -6090,7 +6228,7 @@
       "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0"
+        "lodash._getnative": "3.9.1"
       }
     },
     "lodash.find": {
@@ -6105,8 +6243,8 @@
       "integrity": "sha1-3hz1d1j49EeTGdNcPpzGDEUBk4w=",
       "dev": true,
       "requires": {
-        "lodash._baseflatten": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0"
+        "lodash._baseflatten": "3.1.4",
+        "lodash._isiterateecall": "3.0.9"
       }
     },
     "lodash.isarguments": {
@@ -6133,7 +6271,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "4.0.0"
       }
     },
     "loud-rejection": {
@@ -6142,8 +6280,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lru-cache": {
@@ -6170,7 +6308,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "matchdep": {
@@ -6179,7 +6317,7 @@
       "integrity": "sha1-L1OfCB0GnzIFox5hU3Ob/RPGYsY=",
       "dev": true,
       "requires": {
-        "minimatch": "~0.2.9"
+        "minimatch": "0.2.14"
       },
       "dependencies": {
         "minimatch": {
@@ -6188,8 +6326,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         }
       }
@@ -6200,7 +6338,7 @@
       "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.2"
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "minimatch": {
@@ -6209,7 +6347,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -6226,16 +6364,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       }
     },
     "merge-descriptors": {
@@ -6250,8 +6388,8 @@
       "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
       "dev": true,
       "requires": {
-        "fs-updater": "^1.0.4",
-        "heimdalljs": "^0.2.5"
+        "fs-updater": "1.0.4",
+        "heimdalljs": "0.2.6"
       }
     },
     "method-override": {
@@ -6291,19 +6429,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "mime": {
@@ -6324,7 +6462,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimoza": {
@@ -6339,13 +6477,13 @@
       "integrity": "sha1-SUN5gOpjNuxYRA1x6wnOlEU+c9U=",
       "dev": true,
       "requires": {
-        "argparse": "~ 0.1.15",
-        "async": "~ 0.2.9",
-        "fs-tools": "~ 0.2.10",
-        "hike": "~ 0.1.3",
-        "lodash": "~ 2.4.1",
-        "mimoza": "~ 0.3.0",
-        "shellwords": "~ 0.1.0"
+        "argparse": "0.1.16",
+        "async": "0.2.10",
+        "fs-tools": "0.2.11",
+        "hike": "0.1.4",
+        "lodash": "2.4.2",
+        "mimoza": "0.3.0",
+        "shellwords": "0.1.1"
       },
       "dependencies": {
         "argparse": {
@@ -6354,8 +6492,8 @@
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
-            "underscore": "~1.7.0",
-            "underscore.string": "~2.4.0"
+            "underscore": "1.7.0",
+            "underscore.string": "2.4.0"
           }
         },
         "async": {
@@ -6384,8 +6522,8 @@
       "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
       "dev": true,
       "requires": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
       }
     },
     "minimist": {
@@ -6400,8 +6538,8 @@
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
       },
       "dependencies": {
         "safe-buffer": {
@@ -6418,8 +6556,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -6428,7 +6566,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -6485,8 +6623,8 @@
       "integrity": "sha1-veITAdrSlChuFVsrYHEMauBK5k8=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.1.9",
-        "stream-counter": "~0.2.0"
+        "readable-stream": "1.1.14",
+        "stream-counter": "0.2.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -6495,10 +6633,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "stream-counter": {
@@ -6507,7 +6645,7 @@
           "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.1.8"
+            "readable-stream": "1.1.14"
           }
         }
       }
@@ -6531,18 +6669,18 @@
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -6583,11 +6721,11 @@
       "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
       "dev": true,
       "requires": {
-        "growly": "^1.3.0",
-        "is-wsl": "^1.1.0",
-        "semver": "^5.5.0",
-        "shellwords": "^0.1.1",
-        "which": "^1.3.0"
+        "growly": "1.3.0",
+        "is-wsl": "1.1.0",
+        "semver": "5.5.0",
+        "shellwords": "0.1.1",
+        "which": "1.3.1"
       },
       "dependencies": {
         "which": {
@@ -6596,18 +6734,18 @@
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         }
       }
     },
     "node-releases": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.13.tgz",
-      "integrity": "sha512-fKZGviSXR6YvVPyc011NHuJDSD8gFQvLPmc2d2V3BS4gr52ycyQ1Xzs7a8B+Ax3Ni/W+5h1h4SqmzeoA8WZRmA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.19.tgz",
+      "integrity": "sha512-SH/B4WwovHbulIALsQllAVwqZZD1kPmKCqrhGfR29dXjLAVZMHvBjD3S6nL9D/J9QkmZ1R92/0wCMDKXUUvyyA==",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.5.0"
       }
     },
     "node-uuid": {
@@ -6622,7 +6760,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -6631,10 +6769,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.2"
       }
     },
     "normalize-path": {
@@ -6643,7 +6781,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "npm-run-path": {
@@ -6652,7 +6790,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npmlog": {
@@ -6661,10 +6799,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "number-is-nan": {
@@ -6697,9 +6835,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -6708,7 +6846,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -6725,7 +6863,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -6742,8 +6880,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -6752,7 +6890,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -6784,7 +6922,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "os-tmpdir": {
@@ -6805,7 +6943,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -6814,7 +6952,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-try": {
@@ -6829,10 +6967,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-json": {
@@ -6841,7 +6979,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-passwd": {
@@ -6856,7 +6994,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -6865,7 +7003,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -6886,7 +7024,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -6919,7 +7057,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -6940,9 +7078,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "pause": {
@@ -6969,7 +7107,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-up": {
@@ -6978,7 +7116,7 @@
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -6987,7 +7125,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -7028,7 +7166,7 @@
       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
       "dev": true,
       "requires": {
-        "rsvp": "^3.0.14"
+        "rsvp": "3.6.2"
       }
     },
     "proxy-addr": {
@@ -7037,7 +7175,7 @@
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "dev": true,
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -7047,8 +7185,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "q": {
@@ -7069,23 +7207,23 @@
       "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
       "dev": true,
       "requires": {
-        "mktemp": "~0.4.0",
-        "rimraf": "^2.5.4",
-        "underscore.string": "~3.3.4"
+        "mktemp": "0.4.0",
+        "rimraf": "2.6.3",
+        "underscore.string": "3.3.5"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -7094,7 +7232,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -7103,7 +7241,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.4"
           }
         },
         "underscore.string": {
@@ -7112,8 +7250,8 @@
           "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
           "dev": true,
           "requires": {
-            "sprintf-js": "^1.0.3",
-            "util-deprecate": "^1.0.2"
+            "sprintf-js": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         }
       }
@@ -7130,7 +7268,7 @@
         "findup-sync": "2.0.0",
         "js-reporters": "1.2.1",
         "resolve": "1.5.0",
-        "shelljs": "^0.2.6",
+        "shelljs": "0.2.6",
         "walk-sync": "0.3.2"
       },
       "dependencies": {
@@ -7152,16 +7290,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7170,7 +7308,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7196,13 +7334,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -7211,7 +7349,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -7220,7 +7358,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -7229,7 +7367,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -7238,7 +7376,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -7249,7 +7387,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -7258,7 +7396,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -7269,9 +7407,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -7288,14 +7426,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -7304,7 +7442,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -7313,7 +7451,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7324,10 +7462,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7336,7 +7474,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7347,10 +7485,10 @@
           "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
           "dev": true,
           "requires": {
-            "detect-file": "^1.0.0",
-            "is-glob": "^3.1.0",
-            "micromatch": "^3.0.4",
-            "resolve-dir": "^1.0.1"
+            "detect-file": "1.0.0",
+            "is-glob": "3.1.0",
+            "micromatch": "3.1.10",
+            "resolve-dir": "1.0.1"
           }
         },
         "is-accessor-descriptor": {
@@ -7359,7 +7497,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -7368,7 +7506,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -7377,9 +7515,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -7394,7 +7532,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -7403,7 +7541,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7412,7 +7550,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7435,19 +7573,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "resolve": {
@@ -7456,7 +7594,7 @@
           "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.5"
+            "path-parse": "1.0.5"
           }
         },
         "shelljs": {
@@ -7473,8 +7611,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -7483,7 +7621,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7492,7 +7630,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7503,7 +7641,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -7545,9 +7683,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -7556,8 +7694,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -7566,10 +7704,10 @@
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
         "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "string_decoder": "0.10.31"
       }
     },
     "readdirp": {
@@ -7578,10 +7716,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -7596,7 +7734,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "readable-stream": {
@@ -7605,13 +7743,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -7620,7 +7758,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -7632,9 +7770,9 @@
       "dev": true,
       "requires": {
         "ast-types": "0.9.6",
-        "esprima": "~3.1.0",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
+        "esprima": "3.1.3",
+        "private": "0.1.8",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "esprima": {
@@ -7657,7 +7795,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.1.7"
       }
     },
     "redent": {
@@ -7666,8 +7804,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "reduce-component": {
@@ -7683,12 +7821,12 @@
       "dev": true
     },
     "regenerate-unicode-properties": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz",
-      "integrity": "sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0"
+        "regenerate": "1.4.0"
       }
     },
     "regenerator-runtime": {
@@ -7703,7 +7841,7 @@
       "integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
       "dev": true,
       "requires": {
-        "private": "^0.1.6"
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -7712,7 +7850,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -7721,14 +7859,14 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexp-tree": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.5.tgz",
-      "integrity": "sha512-nUmxvfJyAODw+0B13hj8CFVAxhe7fDEAgJgaotBu3nnR+IgGgZq59YedJP5VYTlkEfqjuK6TuRpnymKdatLZfQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.6.tgz",
+      "integrity": "sha512-LFrA98Dw/heXqDojz7qKFdygZmFoiVlvE1Zp7Cq2cvF+ZA+03Gmhy0k0PQlsC1jvHPiTUSs+pDHEuSWv6+6D7w==",
       "dev": true
     },
     "regexpu-core": {
@@ -7737,12 +7875,12 @@
       "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.0.2",
-        "regjsgen": "^0.5.0",
-        "regjsparser": "^0.6.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.1.0"
+        "regenerate": "1.4.0",
+        "regenerate-unicode-properties": "8.1.0",
+        "regjsgen": "0.5.0",
+        "regjsparser": "0.6.0",
+        "unicode-match-property-ecmascript": "1.0.4",
+        "unicode-match-property-value-ecmascript": "1.1.0"
       }
     },
     "regjsgen": {
@@ -7757,7 +7895,7 @@
       "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -7792,7 +7930,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "request": {
@@ -7801,18 +7939,18 @@
       "integrity": "sha1-VyirnEXlqHyZ2szVMCmLZnOoaNc=",
       "dev": true,
       "requires": {
-        "aws-sign": "~0.3.0",
-        "cookie-jar": "~0.3.0",
-        "forever-agent": "~0.5.0",
+        "aws-sign": "0.3.0",
+        "cookie-jar": "0.3.0",
+        "forever-agent": "0.5.2",
         "form-data": "0.0.8",
-        "hawk": "~0.13.0",
-        "http-signature": "~0.9.11",
-        "json-stringify-safe": "~4.0.0",
-        "mime": "~1.2.9",
-        "node-uuid": "~1.4.0",
-        "oauth-sign": "~0.3.0",
-        "qs": "~0.6.0",
-        "tunnel-agent": "~0.3.0"
+        "hawk": "0.13.1",
+        "http-signature": "0.9.11",
+        "json-stringify-safe": "4.0.0",
+        "mime": "1.2.11",
+        "node-uuid": "1.4.8",
+        "oauth-sign": "0.3.0",
+        "qs": "0.6.5",
+        "tunnel-agent": "0.3.0"
       }
     },
     "requires-port": {
@@ -7839,18 +7977,18 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-package-path": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-1.2.6.tgz",
-      "integrity": "sha512-He6cGWU74tJ6wLYSKrbvWOfIXf2tUu5RcBWqX/2K9Ju00CncF5WRdCOJQisqCtaULcqIqpLvMtz8ZjfpwlBwqg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-1.2.7.tgz",
+      "integrity": "sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==",
       "dev": true,
       "requires": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.10.0"
+        "path-root": "0.1.1",
+        "resolve": "1.10.1"
       },
       "dependencies": {
         "path-parse": {
@@ -7860,12 +7998,12 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "path-parse": "1.0.6"
           }
         }
       }
@@ -7915,7 +8053,7 @@
       "integrity": "sha1-dv8JcydEtF14XuHXkBol65QAMKI=",
       "dev": true,
       "requires": {
-        "knox": "~0.8.3"
+        "knox": "0.8.10"
       }
     },
     "safe-buffer": {
@@ -7930,7 +8068,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -7963,9 +8101,9 @@
       "integrity": "sha1-C8/L0D3vbi2GEuGr+PSJW0UMYMg=",
       "dev": true,
       "requires": {
-        "debug": "*",
+        "debug": "3.1.0",
         "fresh": "0.1.0",
-        "mime": "~1.2.9",
+        "mime": "1.2.11",
         "range-parser": "0.0.4"
       }
     },
@@ -8051,7 +8189,7 @@
             "finished": "1.2.2",
             "fresh": "0.2.2",
             "mime": "1.2.11",
-            "range-parser": "~1.0.0"
+            "range-parser": "1.0.3"
           }
         }
       }
@@ -8074,10 +8212,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -8086,7 +8224,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -8103,7 +8241,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -8142,7 +8280,7 @@
       "integrity": "sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==",
       "dev": true,
       "requires": {
-        "debug": "^2.2.0"
+        "debug": "2.6.9"
       },
       "dependencies": {
         "debug": {
@@ -8162,14 +8300,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -8187,7 +8325,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -8196,7 +8334,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "source-map": {
@@ -8213,9 +8351,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -8224,7 +8362,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -8233,7 +8371,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -8242,7 +8380,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -8251,9 +8389,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -8276,7 +8414,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "sntp": {
@@ -8285,7 +8423,7 @@
       "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
       "dev": true,
       "requires": {
-        "hoek": "0.9.x"
+        "hoek": "0.9.1"
       },
       "dependencies": {
         "hoek": {
@@ -8302,12 +8440,12 @@
       "integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
       "dev": true,
       "requires": {
-        "debug": "~4.1.0",
-        "engine.io": "~3.3.1",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "4.1.1",
+        "engine.io": "3.3.2",
+        "has-binary2": "1.0.3",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.2.0",
-        "socket.io-parser": "~3.3.0"
+        "socket.io-parser": "3.3.0"
       },
       "dependencies": {
         "debug": {
@@ -8316,7 +8454,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "ms": {
@@ -8343,15 +8481,15 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.3.1",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "engine.io-client": "3.3.2",
+        "has-binary2": "1.0.3",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.3.0",
+        "socket.io-parser": "3.3.0",
         "to-array": "0.1.4"
       }
     },
@@ -8362,7 +8500,7 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
+        "debug": "3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -8380,7 +8518,7 @@
       "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
       "dev": true,
       "requires": {
-        "amdefine": ">=0.0.4"
+        "amdefine": "1.0.1"
       }
     },
     "source-map-resolve": {
@@ -8389,11 +8527,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "^2.0.0",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-url": {
@@ -8414,8 +8552,8 @@
       "integrity": "sha512-c+4gPpt9YDhz7cHlz5UrsHzxxRi4ksclxnEEKsuGT9JdwSC+ZNmsGbYRzzgxyZaBYpcWnlu+4lPcdLKx4DOCmA==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^2.0.1",
-        "spdx-license-ids": "^2.0.1"
+        "spdx-expression-parse": "2.0.2",
+        "spdx-license-ids": "2.0.1"
       },
       "dependencies": {
         "spdx-expression-parse": {
@@ -8424,8 +8562,8 @@
           "integrity": "sha512-oFxOkWCfFS0ltNp0H66gXlU4NF6bxg7RkoTYR0413t+yTY9zyj+AIWsjtN8dcVp6703ijDYBWBIARlJ7DkyP9Q==",
           "dev": true,
           "requires": {
-            "spdx-exceptions": "^2.0.0",
-            "spdx-license-ids": "^2.0.1"
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "2.0.1"
           }
         }
       }
@@ -8442,8 +8580,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       },
       "dependencies": {
         "spdx-license-ids": {
@@ -8466,7 +8604,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -8481,8 +8619,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -8491,7 +8629,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -8508,7 +8646,7 @@
       "integrity": "sha1-oDXkKTYftX82Fgbhf82Ki5Z3Mns=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.0.2"
+        "readable-stream": "1.0.34"
       }
     },
     "string-width": {
@@ -8517,9 +8655,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -8534,7 +8672,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -8543,7 +8681,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-eof": {
@@ -8558,7 +8696,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -8585,13 +8723,13 @@
       "integrity": "sha1-HA3cOvMOgOuE68BcshItqP6UC1U=",
       "dev": true,
       "requires": {
-        "component-emitter": "~1.2.0",
+        "component-emitter": "1.2.1",
         "cookiejar": "2.0.6",
-        "debug": "2",
+        "debug": "2.6.9",
         "extend": "3.0.0",
         "form-data": "1.0.0-rc3",
-        "formidable": "~1.0.14",
-        "methods": "~1.1.1",
+        "formidable": "1.0.14",
+        "methods": "1.1.2",
         "mime": "1.3.4",
         "qs": "2.3.3",
         "readable-stream": "1.0.27-1",
@@ -8604,7 +8742,7 @@
           "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
           "dev": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "debug": {
@@ -8628,9 +8766,9 @@
           "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
           "dev": true,
           "requires": {
-            "async": "^1.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.3"
+            "async": "1.5.2",
+            "combined-stream": "1.0.7",
+            "mime-types": "2.1.18"
           }
         },
         "mime": {
@@ -8651,10 +8789,10 @@
           "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         }
       }
@@ -8677,9 +8815,9 @@
       "integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
       "dev": true,
       "requires": {
-        "events-to-array": "^1.0.1",
-        "js-yaml": "^3.2.7",
-        "minipass": "^2.2.0"
+        "events-to-array": "1.1.2",
+        "js-yaml": "3.5.5",
+        "minipass": "2.3.5"
       }
     },
     "testem": {
@@ -8688,34 +8826,34 @@
       "integrity": "sha512-tldpNPCzXfibmxOoTMGOfr8ztUiHf9292zSXCu7SitBx9dCK83k7vEoa77qJBS9t3RGCQCRF+GNMUuiFw//Mbw==",
       "dev": true,
       "requires": {
-        "backbone": "^1.1.2",
-        "bluebird": "^3.4.6",
-        "charm": "^1.0.0",
-        "commander": "^2.6.0",
-        "consolidate": "^0.15.1",
-        "execa": "^1.0.0",
-        "express": "^4.10.7",
-        "fireworm": "^0.7.0",
-        "glob": "^7.0.4",
-        "http-proxy": "^1.13.1",
-        "js-yaml": "^3.2.5",
-        "lodash.assignin": "^4.1.0",
-        "lodash.castarray": "^4.4.0",
-        "lodash.clonedeep": "^4.4.1",
-        "lodash.find": "^4.5.1",
-        "lodash.uniqby": "^4.7.0",
-        "mkdirp": "^0.5.1",
-        "mustache": "^3.0.0",
-        "node-notifier": "^5.0.1",
-        "npmlog": "^4.0.0",
-        "printf": "^0.5.1",
-        "rimraf": "^2.4.4",
-        "socket.io": "^2.1.0",
-        "spawn-args": "^0.2.0",
+        "backbone": "1.4.0",
+        "bluebird": "3.5.4",
+        "charm": "1.0.2",
+        "commander": "2.20.0",
+        "consolidate": "0.15.1",
+        "execa": "1.0.0",
+        "express": "4.16.4",
+        "fireworm": "0.7.1",
+        "glob": "7.1.3",
+        "http-proxy": "1.17.0",
+        "js-yaml": "3.5.5",
+        "lodash.assignin": "4.2.0",
+        "lodash.castarray": "4.4.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.find": "4.6.0",
+        "lodash.uniqby": "4.7.0",
+        "mkdirp": "0.5.1",
+        "mustache": "3.0.1",
+        "node-notifier": "5.4.0",
+        "npmlog": "4.1.2",
+        "printf": "0.5.1",
+        "rimraf": "2.6.3",
+        "socket.io": "2.2.0",
+        "spawn-args": "0.2.0",
         "styled_string": "0.0.1",
-        "tap-parser": "^7.0.0",
+        "tap-parser": "7.0.0",
         "tmp": "0.0.33",
-        "xmldom": "^0.1.19"
+        "xmldom": "0.1.27"
       },
       "dependencies": {
         "glob": {
@@ -8724,12 +8862,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -8738,7 +8876,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "rimraf": {
@@ -8747,7 +8885,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.3"
           }
         },
         "tmp": {
@@ -8756,7 +8894,7 @@
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "~1.0.2"
+            "os-tmpdir": "1.0.2"
           }
         }
       }
@@ -8773,12 +8911,12 @@
       "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
       "dev": true,
       "requires": {
-        "body-parser": "~1.14.0",
-        "debug": "~2.2.0",
-        "faye-websocket": "~0.10.0",
-        "livereload-js": "^2.2.0",
-        "parseurl": "~1.3.0",
-        "qs": "~5.1.0"
+        "body-parser": "1.14.2",
+        "debug": "2.2.0",
+        "faye-websocket": "0.10.0",
+        "livereload-js": "2.3.0",
+        "parseurl": "1.3.2",
+        "qs": "5.1.0"
       },
       "dependencies": {
         "debug": {
@@ -8810,7 +8948,7 @@
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-array": {
@@ -8831,7 +8969,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -8840,10 +8978,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -8852,8 +8990,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -8862,7 +9000,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -8873,11 +9011,11 @@
       "integrity": "sha512-YvYllqh3qrR5TAYZZTXdspnIhlKAYezPYw11ntmweoceu4VK+keN356phHRIIo1d+RDmLpHZrUlmxga2gc9kSQ==",
       "dev": true,
       "requires": {
-        "debug": "^2.2.0",
-        "fs-tree-diff": "^0.5.6",
-        "mkdirp": "^0.5.1",
-        "quick-temp": "^0.1.5",
-        "walk-sync": "^0.3.3"
+        "debug": "2.6.9",
+        "fs-tree-diff": "0.5.9",
+        "mkdirp": "0.5.1",
+        "quick-temp": "0.1.8",
+        "walk-sync": "0.3.4"
       },
       "dependencies": {
         "debug": {
@@ -8895,8 +9033,8 @@
           "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
           "dev": true,
           "requires": {
-            "ensure-posix-path": "^1.0.0",
-            "matcher-collection": "^1.0.0"
+            "ensure-posix-path": "1.0.2",
+            "matcher-collection": "1.0.5"
           }
         }
       }
@@ -8926,7 +9064,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.18"
       }
     },
     "uglify-js": {
@@ -8935,10 +9073,10 @@
       "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
       "dev": true,
       "requires": {
-        "async": "~0.2.6",
+        "async": "0.2.10",
         "source-map": "0.1.34",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.5.4"
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.5.4"
       },
       "dependencies": {
         "async": {
@@ -8985,8 +9123,8 @@
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
+        "unicode-canonical-property-names-ecmascript": "1.0.4",
+        "unicode-property-aliases-ecmascript": "1.0.5"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -9007,10 +9145,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -9019,7 +9157,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -9028,10 +9166,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -9048,8 +9186,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -9058,9 +9196,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -9106,7 +9244,7 @@
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -9141,8 +9279,8 @@
       "integrity": "sha512-8zlGw3EZDpC7iUDKy4yHCSqFwkBTeAK4h1QqDC3ST6rT7dzvu2ZuclExZN7zuXNEhQ3+2UBQgdca5eNNL06sBg==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^2.0.4",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "2.0.4",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vary": {
@@ -9163,8 +9301,8 @@
       "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
       "dev": true,
       "requires": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
+        "ensure-posix-path": "1.0.2",
+        "matcher-collection": "1.0.5"
       }
     },
     "websocket-driver": {
@@ -9173,8 +9311,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.4.10",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -9189,7 +9327,7 @@
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "wide-align": {
@@ -9198,7 +9336,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "1.0.2"
       }
     },
     "window-size": {
@@ -9219,9 +9357,9 @@
       "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.3.4",
+        "@babel/core": "7.4.4",
         "object-assign": "4.1.1",
-        "rsvp": "^4.8.4"
+        "rsvp": "4.8.4"
       },
       "dependencies": {
         "rsvp": {
@@ -9244,7 +9382,7 @@
       "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "1.0.0"
       }
     },
     "xml2js": {
@@ -9253,7 +9391,7 @@
       "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
       "dev": true,
       "requires": {
-        "sax": "0.5.x"
+        "sax": "0.5.8"
       }
     },
     "xmldom": {
@@ -9280,8 +9418,8 @@
       "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
       "dev": true,
       "requires": {
-        "camelcase": "^1.0.2",
-        "decamelize": "^1.0.0",
+        "camelcase": "1.2.1",
+        "decamelize": "1.2.0",
         "window-size": "0.1.0",
         "wordwrap": "0.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "no",
   "license": "MIT",
   "devDependencies": {
-    "ember-source": "3.8.1",
+    "ember-source": "3.10.0",
     "glob": "~3.2.1",
     "grunt": "~1.0.1",
     "grunt-contrib-clean": "~0.4.1",
@@ -34,5 +34,5 @@
     "matchdep": "~0.1.2",
     "qunit": "~2.5"
   },
-  "version": "3.0.0"
+  "version": "3.10.0-intercom.1"
 }

--- a/packages/ember-model/lib/version.js
+++ b/packages/ember-model/lib/version.js
@@ -1,4 +1,4 @@
-var VERSION = '3.8.0-intercom.1';
+var VERSION = '3.10.0-intercom.1';
 
 if (Ember.libraries) {
   Ember.libraries.register('Ember Model', VERSION);

--- a/packages/ember-model/tests/belongs_to_test.js
+++ b/packages/ember-model/tests/belongs_to_test.js
@@ -13,7 +13,7 @@ QUnit.test("is a CP macro", function(assert) {
         article: cp
       });
 
-  assert.ok(cp instanceof Ember.ComputedProperty);
+  assert.ok(Ember.Model._isDescriptor(cp));
 });
 
 QUnit.test("using it in a model definition", function(assert) {

--- a/packages/ember-model/tests/has_many_test.js
+++ b/packages/ember-model/tests/has_many_test.js
@@ -17,7 +17,7 @@ QUnit.test("is a CP macro", function(assert) {
 
   Comment.primaryKey = 'token';
 
-  assert.ok(cp instanceof Ember.ComputedProperty);
+  assert.ok(Ember.Model._isDescriptor(cp));
 
   var article = Article.create();
   Ember.run(article, article.load, 1, {comments: Ember.A([{token: 'a'}, {token: 'b'}])});
@@ -39,7 +39,7 @@ var Comment = Ember.Model.extend({
 
   Comment.primaryKey = 'token';
 
-  assert.ok(cp instanceof Ember.ComputedProperty);
+  assert.ok(Ember.Model._isDescriptor(cp));
 
   var article = Article.create();
   Ember.run(article, article.load, 1, {comments: Ember.A([1, 2])});


### PR DESCRIPTION
This makes `ember-model` compatible with Ember 3.10. I'll publish the `3.10.0-intercom.1` tag once this has merged.

<img width="1200" alt="Screen Shot 2019-05-28 at 09 57 11" src="https://user-images.githubusercontent.com/2526/58465176-080c9880-812f-11e9-855b-77ba21237acd.png">
