### PR TITLE
3.10.0-intercom.2

### DIFF
--- a/ember-model.js
+++ b/ember-model.js
@@ -4,11 +4,11 @@
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-// 3.10.0-intercom.1
-// 362dcfb (2019-05-14 14:20:15 +0100)
+// 3.10.0-intercom.2
+// d30701d (2019-05-28 10:24:33 +0100)
 
 (function() {
-  var VERSION = "3.10.0-intercom.1";
+  var VERSION = "3.10.0-intercom.2";
 
   if (Ember.libraries) {
     Ember.libraries.register("Ember Model", VERSION);
@@ -756,7 +756,7 @@
     },
 
     didDefineProperty: function(proto, key, value) {
-      if (isDescriptor(value)) {
+      if (isDescriptor(value) && value.meta) {
         var meta = value.meta();
         var klass = proto.constructor;
 

--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
     "matchdep": "~0.1.2",
     "qunit": "~2.5"
   },
-  "version": "3.10.0-intercom.1"
+  "version": "3.10.0-intercom.2"
 }

--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -150,7 +150,7 @@ Ember.Model = Ember.Object.extend(Ember.Evented, {
   },
 
   didDefineProperty: function(proto, key, value) {
-    if (isDescriptor(value)) {
+    if (isDescriptor(value) && value.meta) {
       var meta = value.meta();
       var klass = proto.constructor;
 

--- a/packages/ember-model/lib/version.js
+++ b/packages/ember-model/lib/version.js
@@ -1,4 +1,4 @@
-var VERSION = '3.10.0-intercom.1';
+var VERSION = '3.10.0-intercom.2';
 
 if (Ember.libraries) {
   Ember.libraries.register('Ember Model', VERSION);


### PR DESCRIPTION
Follows https://github.com/intercom/ember-model/pull/11

This adds a `.meta` guard which seems to be required to exclude ember concurrency CPs.

<img width="1001" alt="Screen Shot 2019-05-29 at 12 34 31" src="https://user-images.githubusercontent.com/2526/58553941-22697380-820e-11e9-8ca4-3da80f4af96f.png">
